### PR TITLE
Fix typo in header Hyperbolic.swift -> Matrix.swift

### DIFF
--- a/Source/Matrix.swift
+++ b/Source/Matrix.swift
@@ -1,4 +1,4 @@
-// Hyperbolic.swift
+// Matrix.swift
 //
 // Copyright (c) 2014–2015 Mattt Thompson (http://mattt.me)
 //


### PR DESCRIPTION
A simple typo fix.  Using this change to demonstrate how one might contribute to open source!
http://www.meetup.com/OCiOSDev/events/223538696/
