### PR TITLE
Public arithmetic operators

### DIFF
--- a/Source/Arithmetic.swift
+++ b/Source/Arithmetic.swift
@@ -283,91 +283,91 @@ public func dist(x: [Double], y: [Double]) -> Double {
 
 // MARK: - Operators
 
-func + (lhs: [Float], rhs: [Float]) -> [Float] {
+public func + (lhs: [Float], rhs: [Float]) -> [Float] {
     return add(lhs, y: rhs)
 }
 
-func + (lhs: [Double], rhs: [Double]) -> [Double] {
+public func + (lhs: [Double], rhs: [Double]) -> [Double] {
     return add(lhs, y: rhs)
 }
 
-func + (lhs: [Float], rhs: Float) -> [Float] {
+public func + (lhs: [Float], rhs: Float) -> [Float] {
     return add(lhs, y: [Float](count: lhs.count, repeatedValue: rhs))
 }
 
-func + (lhs: [Double], rhs: Double) -> [Double] {
+public func + (lhs: [Double], rhs: Double) -> [Double] {
     return add(lhs, y: [Double](count: lhs.count, repeatedValue: rhs))
 }
 
-func - (lhs: [Float], rhs: [Float]) -> [Float] {
+public func - (lhs: [Float], rhs: [Float]) -> [Float] {
     return sub(lhs, y: rhs)
 }
 
-func - (lhs: [Double], rhs: [Double]) -> [Double] {
+public func - (lhs: [Double], rhs: [Double]) -> [Double] {
     return sub(lhs, y: rhs)
 }
 
-func - (lhs: [Float], rhs: Float) -> [Float] {
+public func - (lhs: [Float], rhs: Float) -> [Float] {
     return sub(lhs, y: [Float](count: lhs.count, repeatedValue: rhs))
 }
 
-func - (lhs: [Double], rhs: Double) -> [Double] {
+public func - (lhs: [Double], rhs: Double) -> [Double] {
     return sub(lhs, y: [Double](count: lhs.count, repeatedValue: rhs))
 }
 
-func / (lhs: [Float], rhs: [Float]) -> [Float] {
+public func / (lhs: [Float], rhs: [Float]) -> [Float] {
     return div(lhs, y: rhs)
 }
 
-func / (lhs: [Double], rhs: [Double]) -> [Double] {
+public func / (lhs: [Double], rhs: [Double]) -> [Double] {
     return div(lhs, y: rhs)
 }
 
-func / (lhs: [Float], rhs: Float) -> [Float] {
+public func / (lhs: [Float], rhs: Float) -> [Float] {
     return div(lhs, y: [Float](count: lhs.count, repeatedValue: rhs))
 }
 
-func / (lhs: [Double], rhs: Double) -> [Double] {
+public func / (lhs: [Double], rhs: Double) -> [Double] {
     return div(lhs, y: [Double](count: lhs.count, repeatedValue: rhs))
 }
 
-func * (lhs: [Float], rhs: [Float]) -> [Float] {
+public func * (lhs: [Float], rhs: [Float]) -> [Float] {
     return mul(lhs, y: rhs)
 }
 
-func * (lhs: [Double], rhs: [Double]) -> [Double] {
+public func * (lhs: [Double], rhs: [Double]) -> [Double] {
     return mul(lhs, y: rhs)
 }
 
-func * (lhs: [Float], rhs: Float) -> [Float] {
+public func * (lhs: [Float], rhs: Float) -> [Float] {
     return mul(lhs, y: [Float](count: lhs.count, repeatedValue: rhs))
 }
 
-func * (lhs: [Double], rhs: Double) -> [Double] {
+public func * (lhs: [Double], rhs: Double) -> [Double] {
     return mul(lhs, y: [Double](count: lhs.count, repeatedValue: rhs))
 }
 
-func % (lhs: [Float], rhs: [Float]) -> [Float] {
+public func % (lhs: [Float], rhs: [Float]) -> [Float] {
     return mod(lhs, y: rhs)
 }
 
-func % (lhs: [Double], rhs: [Double]) -> [Double] {
+public func % (lhs: [Double], rhs: [Double]) -> [Double] {
     return mod(lhs, y: rhs)
 }
 
-func % (lhs: [Float], rhs: Float) -> [Float] {
+public func % (lhs: [Float], rhs: Float) -> [Float] {
     return mod(lhs, y: [Float](count: lhs.count, repeatedValue: rhs))
 }
 
-func % (lhs: [Double], rhs: Double) -> [Double] {
+public func % (lhs: [Double], rhs: Double) -> [Double] {
     return mod(lhs, y: [Double](count: lhs.count, repeatedValue: rhs))
 }
 
 infix operator • {}
-func • (lhs: [Double], rhs: [Double]) -> Double {
+public func • (lhs: [Double], rhs: [Double]) -> Double {
     return dot(lhs, y: rhs)
 }
 
-func • (lhs: [Float], rhs: [Float]) -> Float {
+public func • (lhs: [Float], rhs: [Float]) -> Float {
     return dot(lhs, y: rhs)
 }

--- a/Source/Arithmetic.swift
+++ b/Source/Arithmetic.swift
@@ -144,6 +144,22 @@ public func add(x: [Double], y: [Double]) -> [Double] {
     return results
 }
 
+// MARK: Subtraction
+
+public func sub(x: [Float], y: [Float]) -> [Float] {
+    var results = [Float](y)
+    catlas_saxpby(Int32(x.count), 1.0, x, 1, -1, &results, 1)
+    
+    return results
+}
+
+public func sub(x: [Double], y: [Double]) -> [Double] {
+    var results = [Double](y)
+    catlas_daxpby(Int32(x.count), 1.0, x, 1, -1, &results, 1)
+    
+    return results
+}
+
 // MARK: Multiply
 
 public func mul(x: [Float], y: [Float]) -> [Float] {
@@ -281,6 +297,22 @@ func + (lhs: [Float], rhs: Float) -> [Float] {
 
 func + (lhs: [Double], rhs: Double) -> [Double] {
     return add(lhs, y: [Double](count: lhs.count, repeatedValue: rhs))
+}
+
+func - (lhs: [Float], rhs: [Float]) -> [Float] {
+    return sub(lhs, y: rhs)
+}
+
+func - (lhs: [Double], rhs: [Double]) -> [Double] {
+    return sub(lhs, y: rhs)
+}
+
+func - (lhs: [Float], rhs: Float) -> [Float] {
+    return sub(lhs, y: [Float](count: lhs.count, repeatedValue: rhs))
+}
+
+func - (lhs: [Double], rhs: Double) -> [Double] {
+    return sub(lhs, y: [Double](count: lhs.count, repeatedValue: rhs))
 }
 
 func / (lhs: [Float], rhs: [Float]) -> [Float] {


### PR DESCRIPTION
I made the arithmetic operators in Arithmetic.swift `public` so that they can be accessed outside of the framework itself. If the decision to keep these operators non-public was intentional, I'd be interested to learn about why/how. Thanks! 

