### PR TITLE
Fix error in specification of workspace size in call to dgeev_

### DIFF
--- a/Source/Matrix.swift
+++ b/Source/Matrix.swift
@@ -252,7 +252,7 @@ public func eigendecompostion(x: Matrix<Double>) ->(Matrix<Double>, [Double]) {
     lwork = __CLPK_integer(workspaceQuery)
 
     "V".withCString { (V) -> Void in
-        dgeev_(UnsafeMutablePointer(V), UnsafeMutablePointer(V), &N, &mat, &N, &wr, &wi, &vl, &N, &vr, &N, &workspaceQuery, &lwork, &error)
+        dgeev_(UnsafeMutablePointer(V), UnsafeMutablePointer(V), &N, &mat, &N, &wr, &wi, &vl, &N, &vr, &N, &workspace, &lwork, &error)
     }
 
     var eigenVectors: Matrix<Double> = Matrix(rows: Int(N), columns: Int(N), repeatedValue: 0.0)


### PR DESCRIPTION
This fixes an error on a stale branch that added eigenvalue decomposition to Matrix.swift. The initial call to dgeev_ to obtain the optimal workspace size was not actually used for the subsequent call to dgeev_ for the actual decomposition.
