### PR TITLE
Changed element-wise operators from + to .+ to resolve #58

### DIFF
--- a/Sources/Surge/Arithmetic.swift
+++ b/Sources/Surge/Arithmetic.swift
@@ -238,7 +238,7 @@ public func dot<X: UnsafeMemoryAccessible, Y: UnsafeMemoryAccessible>(_ x: X, _ 
 
 public func dist<X: UnsafeMemoryAccessible, Y: UnsafeMemoryAccessible>(_ x: X, _ y: Y) -> Float where X.Element == Float, Y.Element == Float {
     precondition(x.count == y.count, "Vectors must have equal count")
-    let sub = x - y
+    let sub = x .- y
     var squared = [Float](repeating: 0.0, count: numericCast(x.count))
     squared.withUnsafeMutableBufferPointer { bufferPointer in
         vDSP_vsq(sub, 1, bufferPointer.baseAddress!, 1, numericCast(x.count))
@@ -248,7 +248,7 @@ public func dist<X: UnsafeMemoryAccessible, Y: UnsafeMemoryAccessible>(_ x: X, _
 
 public func dist<X: UnsafeMemoryAccessible, Y: UnsafeMemoryAccessible>(_ x: X, _ y: Y) -> Double where X.Element == Double, Y.Element == Double {
     precondition(x.count == y.count, "Vectors must have equal count")
-    let sub = x - y
+    let sub = x .- y
     var squared = [Double](repeating: 0.0, count: numericCast(x.count))
     squared.withUnsafeMutableBufferPointer { bufferPointer in
         vDSP_vsqD(sub, 1, bufferPointer.baseAddress!, 1, numericCast(x.count))
@@ -260,7 +260,10 @@ public func dist<X: UnsafeMemoryAccessible, Y: UnsafeMemoryAccessible>(_ x: X, _
 
 // MARK: Elemen-wise addition
 
-public func += <L: UnsafeMutableMemoryAccessible, R: UnsafeMemoryAccessible>(lhs: inout L, rhs: R) where L.Element == Float, R.Element == Float {
+infix operator .+: AdditionPrecedence
+infix operator .+=: AssignmentPrecedence
+
+public func .+= <L: UnsafeMutableMemoryAccessible, R: UnsafeMemoryAccessible>(lhs: inout L, rhs: R) where L.Element == Float, R.Element == Float {
     lhs.withUnsafeMutableMemory { lm in
         rhs.withUnsafeMemory { rm in
             vDSP_vadd(lm.pointer, lm.stride, rm.pointer, rm.stride, lm.pointer, lm.stride, numericCast(lm.count))
@@ -268,7 +271,7 @@ public func += <L: UnsafeMutableMemoryAccessible, R: UnsafeMemoryAccessible>(lhs
     }
 }
 
-public func += <L: UnsafeMutableMemoryAccessible, R: UnsafeMemoryAccessible>(lhs: inout L, rhs: R) where L.Element == Double, R.Element == Double {
+public func .+= <L: UnsafeMutableMemoryAccessible, R: UnsafeMemoryAccessible>(lhs: inout L, rhs: R) where L.Element == Double, R.Element == Double {
     lhs.withUnsafeMutableMemory { lm in
         rhs.withUnsafeMemory { rm in
             vDSP_vaddD(lm.pointer, lm.stride, rm.pointer, rm.stride, lm.pointer, lm.stride, numericCast(lm.count))
@@ -276,11 +279,11 @@ public func += <L: UnsafeMutableMemoryAccessible, R: UnsafeMemoryAccessible>(lhs
     }
 }
 
-public func + <L: UnsafeMemoryAccessible, R: UnsafeMemoryAccessible>(lhs: L, rhs: R) -> [Float] where L.Element == Float, R.Element == Float {
+public func .+ <L: UnsafeMemoryAccessible, R: UnsafeMemoryAccessible>(lhs: L, rhs: R) -> [Float] where L.Element == Float, R.Element == Float {
     return add(lhs, rhs)
 }
 
-public func + <L: UnsafeMemoryAccessible, R: UnsafeMemoryAccessible>(lhs: L, rhs: R) -> [Double] where L.Element == Double, R.Element == Double {
+public func .+ <L: UnsafeMemoryAccessible, R: UnsafeMemoryAccessible>(lhs: L, rhs: R) -> [Double] where L.Element == Double, R.Element == Double {
     return add(lhs, rhs)
 }
 
@@ -310,7 +313,10 @@ public func + <L: UnsafeMemoryAccessible>(lhs: L, rhs: Double) -> [Double] where
 
 // MARK: Element-wise subtraction
 
-public func -= <L: UnsafeMutableMemoryAccessible, R: UnsafeMemoryAccessible>(lhs: inout L, rhs: R) where L.Element == Float, R.Element == Float {
+infix operator .-: AdditionPrecedence
+infix operator .-=: AssignmentPrecedence
+
+public func .-= <L: UnsafeMutableMemoryAccessible, R: UnsafeMemoryAccessible>(lhs: inout L, rhs: R) where L.Element == Float, R.Element == Float {
     lhs.withUnsafeMutableMemory { lm in
         rhs.withUnsafeMemory { rm in
             vDSP_vsub(lm.pointer, lm.stride, rm.pointer, rm.stride, lm.pointer, lm.stride, numericCast(lm.count))
@@ -318,7 +324,7 @@ public func -= <L: UnsafeMutableMemoryAccessible, R: UnsafeMemoryAccessible>(lhs
     }
 }
 
-public func -= <L: UnsafeMutableMemoryAccessible, R: UnsafeMemoryAccessible>(lhs: inout L, rhs: R) where L.Element == Double, R.Element == Double {
+public func .-= <L: UnsafeMutableMemoryAccessible, R: UnsafeMemoryAccessible>(lhs: inout L, rhs: R) where L.Element == Double, R.Element == Double {
     lhs.withUnsafeMutableMemory { lm in
         rhs.withUnsafeMemory { rm in
             vDSP_vsubD(lm.pointer, lm.stride, rm.pointer, rm.stride, lm.pointer, lm.stride, numericCast(lm.count))
@@ -326,11 +332,11 @@ public func -= <L: UnsafeMutableMemoryAccessible, R: UnsafeMemoryAccessible>(lhs
     }
 }
 
-public func - <L: UnsafeMemoryAccessible, R: UnsafeMemoryAccessible>(lhs: L, rhs: R) -> [Float] where L.Element == Float, R.Element == Float {
+public func .- <L: UnsafeMemoryAccessible, R: UnsafeMemoryAccessible>(lhs: L, rhs: R) -> [Float] where L.Element == Float, R.Element == Float {
     return sub(lhs, rhs)
 }
 
-public func - <L: UnsafeMemoryAccessible, R: UnsafeMemoryAccessible>(lhs: L, rhs: R) -> [Double] where L.Element == Double, R.Element == Double {
+public func .- <L: UnsafeMemoryAccessible, R: UnsafeMemoryAccessible>(lhs: L, rhs: R) -> [Double] where L.Element == Double, R.Element == Double {
     return sub(lhs, rhs)
 }
 
@@ -360,7 +366,10 @@ public func - <L: UnsafeMemoryAccessible>(lhs: L, rhs: Double) -> [Double] where
 
 // MARK: Element-wise division
 
-public func /= <L: UnsafeMutableMemoryAccessible, R: UnsafeMemoryAccessible>(lhs: inout L, rhs: R) where L.Element == Float, R.Element == Float {
+infix operator ./: MultiplicationPrecedence
+infix operator ./=: AssignmentPrecedence
+
+public func ./= <L: UnsafeMutableMemoryAccessible, R: UnsafeMemoryAccessible>(lhs: inout L, rhs: R) where L.Element == Float, R.Element == Float {
     lhs.withUnsafeMutableMemory { lm in
         rhs.withUnsafeMemory { rm in
             vDSP_vdiv(lm.pointer, lm.stride, rm.pointer, rm.stride, lm.pointer, lm.stride, numericCast(lm.count))
@@ -368,7 +377,7 @@ public func /= <L: UnsafeMutableMemoryAccessible, R: UnsafeMemoryAccessible>(lhs
     }
 }
 
-public func /= <L: UnsafeMutableMemoryAccessible, R: UnsafeMemoryAccessible>(lhs: inout L, rhs: R) where L.Element == Double, R.Element == Double {
+public func ./= <L: UnsafeMutableMemoryAccessible, R: UnsafeMemoryAccessible>(lhs: inout L, rhs: R) where L.Element == Double, R.Element == Double {
     lhs.withUnsafeMutableMemory { lm in
         rhs.withUnsafeMemory { rm in
             vDSP_vdivD(lm.pointer, lm.stride, rm.pointer, rm.stride, lm.pointer, lm.stride, numericCast(lm.count))
@@ -376,11 +385,11 @@ public func /= <L: UnsafeMutableMemoryAccessible, R: UnsafeMemoryAccessible>(lhs
     }
 }
 
-public func / <L: UnsafeMemoryAccessible, R: UnsafeMemoryAccessible>(lhs: L, rhs: R) -> [Float] where L.Element == Float, R.Element == Float {
+public func ./ <L: UnsafeMemoryAccessible, R: UnsafeMemoryAccessible>(lhs: L, rhs: R) -> [Float] where L.Element == Float, R.Element == Float {
     return div(lhs, rhs)
 }
 
-public func / <L: UnsafeMemoryAccessible, R: UnsafeMemoryAccessible>(lhs: L, rhs: R) -> [Double] where L.Element == Double, R.Element == Double {
+public func ./ <L: UnsafeMemoryAccessible, R: UnsafeMemoryAccessible>(lhs: L, rhs: R) -> [Double] where L.Element == Double, R.Element == Double {
     return div(lhs, rhs)
 }
 
@@ -410,7 +419,10 @@ public func / <L: UnsafeMemoryAccessible>(lhs: L, rhs: Double) -> [Double] where
 
 // MARK: Element-wise multiplication
 
-public func *= <L: UnsafeMutableMemoryAccessible, R: UnsafeMemoryAccessible>(lhs: inout L, rhs: R) where L.Element == Float, R.Element == Float {
+infix operator .*: MultiplicationPrecedence
+infix operator .*=: AssignmentPrecedence
+
+public func .*= <L: UnsafeMutableMemoryAccessible, R: UnsafeMemoryAccessible>(lhs: inout L, rhs: R) where L.Element == Float, R.Element == Float {
     lhs.withUnsafeMutableMemory { lm in
         rhs.withUnsafeMemory { rm in
             vDSP_vmul(lm.pointer, lm.stride, rm.pointer, rm.stride, lm.pointer, lm.stride, numericCast(lm.count))
@@ -418,7 +430,7 @@ public func *= <L: UnsafeMutableMemoryAccessible, R: UnsafeMemoryAccessible>(lhs
     }
 }
 
-public func *= <L: UnsafeMutableMemoryAccessible, R: UnsafeMemoryAccessible>(lhs: inout L, rhs: R) where L.Element == Double, R.Element == Double {
+public func .*= <L: UnsafeMutableMemoryAccessible, R: UnsafeMemoryAccessible>(lhs: inout L, rhs: R) where L.Element == Double, R.Element == Double {
     lhs.withUnsafeMutableMemory { lm in
         rhs.withUnsafeMemory { rm in
             vDSP_vmulD(lm.pointer, lm.stride, rm.pointer, rm.stride, lm.pointer, lm.stride, numericCast(lm.count))
@@ -426,11 +438,11 @@ public func *= <L: UnsafeMutableMemoryAccessible, R: UnsafeMemoryAccessible>(lhs
     }
 }
 
-public func * <L: UnsafeMemoryAccessible, R: UnsafeMemoryAccessible>(lhs: L, rhs: R) -> [Float] where L.Element == Float, R.Element == Float {
+public func .* <L: UnsafeMemoryAccessible, R: UnsafeMemoryAccessible>(lhs: L, rhs: R) -> [Float] where L.Element == Float, R.Element == Float {
     return mul(lhs, rhs)
 }
 
-public func * <L: UnsafeMemoryAccessible, R: UnsafeMemoryAccessible>(lhs: L, rhs: R) -> [Double] where L.Element == Double, R.Element == Double {
+public func .* <L: UnsafeMemoryAccessible, R: UnsafeMemoryAccessible>(lhs: L, rhs: R) -> [Double] where L.Element == Double, R.Element == Double {
     return mul(lhs, rhs)
 }
 
@@ -460,11 +472,14 @@ public func * <L: UnsafeMemoryAccessible>(lhs: L, rhs: Double) -> [Double] where
 
 // MARK: Modulo
 
-public func % <L: UnsafeMemoryAccessible, R: UnsafeMemoryAccessible>(lhs: L, rhs: R) -> [Float] where L.Element == Float, R.Element == Float {
+infix operator .%: MultiplicationPrecedence
+infix operator .%=: AssignmentPrecedence
+
+public func .% <L: UnsafeMemoryAccessible, R: UnsafeMemoryAccessible>(lhs: L, rhs: R) -> [Float] where L.Element == Float, R.Element == Float {
     return mod(lhs, rhs)
 }
 
-public func % <L: UnsafeMemoryAccessible, R: UnsafeMemoryAccessible>(lhs: L, rhs: R) -> [Double] where L.Element == Double, R.Element == Double {
+public func .% <L: UnsafeMemoryAccessible, R: UnsafeMemoryAccessible>(lhs: L, rhs: R) -> [Double] where L.Element == Double, R.Element == Double {
     return mod(lhs, rhs)
 }
 

--- a/Sources/Surge/Matrix.swift
+++ b/Sources/Surge/Matrix.swift
@@ -259,14 +259,14 @@ public func mul(_ x: Matrix<Double>, _ y: Matrix<Double>) -> Matrix<Double> {
 public func elmul(_ x: Matrix<Double>, _ y: Matrix<Double>) -> Matrix<Double> {
     precondition(x.rows == y.rows && x.columns == y.columns, "Matrix must have the same dimensions")
     var result = Matrix<Double>(rows: x.rows, columns: x.columns, repeatedValue: 0.0)
-    result.grid = x.grid * y.grid
+    result.grid = x.grid .* y.grid
     return result
 }
 
 public func elmul(_ x: Matrix<Float>, _ y: Matrix<Float>) -> Matrix<Float> {
     precondition(x.rows == y.rows && x.columns == y.columns, "Matrix must have the same dimensions")
     var result = Matrix<Float>(rows: x.rows, columns: x.columns, repeatedValue: 0.0)
-    result.grid = x.grid * y.grid
+    result.grid = x.grid .* y.grid
     return result
 }
 

--- a/Sources/Surge/Matrix.swift
+++ b/Sources/Surge/Matrix.swift
@@ -37,13 +37,30 @@ public struct Matrix<Scalar> where Scalar: FloatingPoint, Scalar: ExpressibleByF
         self.grid = [Scalar](repeating: repeatedValue, count: rows * columns)
     }
 
-    public init(_ contents: [[Scalar]]) {
-        self.init(rows: contents.count, columns: contents[0].count, repeatedValue: 0.0)
+    public init<T: Collection, U: Collection>(_ contents: T) where T.Element == U, U.Element == Scalar {
+        self.init(rows: contents.count, columns: contents.first!.count, repeatedValue: 0.0)
 
         for (i, row) in contents.enumerated() {
             precondition(row.count == columns, "All rows should have the same number of columns")
             grid.replaceSubrange(i*columns ..< (i + 1)*columns, with: row)
         }
+    }
+
+    public init(row: [Scalar]) {
+        self.init(rows: 1, columns: row.count, grid: row)
+    }
+
+    public init(column: [Scalar]) {
+        self.init(rows: column.count, columns: 1, grid: column)
+    }
+
+    public init(rows: Int, columns: Int, grid: [Scalar]) {
+        precondition(grid.count == rows * columns)
+
+        self.rows = rows
+        self.columns = columns
+
+        self.grid = grid
     }
 
     public subscript(row: Int, column: Int) -> Scalar {
@@ -151,6 +168,7 @@ extension Matrix: Equatable {}
 public func ==<T> (lhs: Matrix<T>, rhs: Matrix<T>) -> Bool {
     return lhs.rows == rhs.rows && lhs.columns == rhs.columns && lhs.grid == rhs.grid
 }
+
 
 // MARK: -
 
@@ -307,6 +325,25 @@ public func sum(_ x: Matrix<Double>, axies: MatrixAxies = .column) -> Matrix<Dou
     }
 }
 
+public func sum(_ x: Matrix<Float>, axies: MatrixAxies = .column) -> Matrix<Float> {
+
+    switch axies {
+    case .column:
+        var result = Matrix<Float>(rows: 1, columns: x.columns, repeatedValue: 0.0)
+        for i in 0..<x.columns {
+            result.grid[i] = sum(x[column: i])
+        }
+        return result
+
+    case .row:
+        var result = Matrix<Float>(rows: x.rows, columns: 1, repeatedValue: 0.0)
+        for i in 0..<x.rows {
+            result.grid[i] = sum(x[row: i])
+        }
+        return result
+    }
+}
+
 public func inv(_ x: Matrix<Float>) -> Matrix<Float> {
     precondition(x.rows == x.columns, "Matrix must be square")
 
@@ -443,6 +480,14 @@ public func - (lhs: Matrix<Float>, rhs: Matrix<Float>) -> Matrix<Float> {
 
 public func - (lhs: Matrix<Double>, rhs: Matrix<Double>) -> Matrix<Double> {
     return sub(lhs, rhs)
+}
+
+public func + (lhs: Matrix<Float>, rhs: Float) -> Matrix<Float> {
+    return Matrix(rows: lhs.rows, columns: lhs.columns, grid: lhs.grid + rhs)
+}
+
+public func + (lhs: Matrix<Double>, rhs: Double) -> Matrix<Double> {
+    return Matrix(rows: lhs.rows, columns: lhs.columns, grid: lhs.grid + rhs)
 }
 
 public func * (lhs: Float, rhs: Matrix<Float>) -> Matrix<Float> {

--- a/Sources/Surge/Statistics.swift
+++ b/Sources/Surge/Statistics.swift
@@ -238,7 +238,7 @@ public func linregress<X: UnsafeMemoryAccessible, Y: UnsafeMemoryAccessible>(_ x
     precondition(x.count == y.count, "Vectors must have equal count")
     let meanx = mean(x)
     let meany = mean(y)
-    let meanxy = mean(x * y)
+    let meanxy = mean(x .* y)
     let meanx_sqr = measq(x)
 
     let slope = (meanx * meany - meanxy) / (meanx * meanx - meanx_sqr)
@@ -256,7 +256,7 @@ public func linregress<X: UnsafeMemoryAccessible, Y: UnsafeMemoryAccessible>(_ x
     precondition(x.count == y.count, "Vectors must have equal count")
     let meanx = mean(x)
     let meany = mean(y)
-    let meanxy = mean(x * y)
+    let meanxy = mean(x .* y)
     let meanx_sqr = measq(x)
 
     let slope = (meanx * meany - meanxy) / (meanx * meanx - meanx_sqr)


### PR DESCRIPTION
As suggested in #58, all element-wise operations on array changed from `+`-style to `.+`-style.

List of changed operators:

* `+` –> `.+`
* `+=` –> `.+=`
* `-` –> `.-`
* `-=` –> `.-=`
* `/` –> `./`
* `/=` –> `./=`
* `*` –> `.*`
* `*=` –> `.*=`
* `%` –> `.%`
* `%=` –> `.%=`
