### PR TITLE
Added Matrix initializers for common diagonal/eye/identity patterns

### DIFF
--- a/Sources/Surge/Matrix.swift
+++ b/Sources/Surge/Matrix.swift
@@ -63,6 +63,14 @@ public struct Matrix<Scalar> where Scalar: FloatingPoint, Scalar: ExpressibleByF
         self.grid = grid
     }
 
+    public static func identity(size: Int) -> Matrix<Scalar> {
+        return self.diagonal(rows: size, columns: size, repeatedValue: 1.0)
+    }
+
+    public static func eye(rows: Int, columns: Int) -> Matrix<Scalar> {
+        return self.diagonal(rows: rows, columns: columns, repeatedValue: 1.0)
+    }
+
     public static func diagonal(rows: Int, columns: Int, repeatedValue: Scalar) -> Matrix<Scalar> {
         let count = Swift.min(rows, columns)
         let scalars = Swift.repeatElement(repeatedValue, count: count)

--- a/Sources/Surge/Matrix.swift
+++ b/Sources/Surge/Matrix.swift
@@ -63,6 +63,25 @@ public struct Matrix<Scalar> where Scalar: FloatingPoint, Scalar: ExpressibleByF
         self.grid = grid
     }
 
+    public static func diagonal(rows: Int, columns: Int, repeatedValue: Scalar) -> Matrix<Scalar> {
+        let count = Swift.min(rows, columns)
+        let scalars = Swift.repeatElement(repeatedValue, count: count)
+        return self.diagonal(rows: rows, columns: columns, scalars: scalars)
+    }
+
+    public static func diagonal<T: Collection>(rows: Int, columns: Int, scalars: T) -> Matrix<Scalar> where T.Element == Scalar {
+        var matrix = self.init(rows: rows, columns: columns, repeatedValue: 0.0)
+
+        let count = Swift.min(rows, columns)
+        precondition(scalars.count == count)
+
+        for (i, scalar) in scalars.enumerated() {
+            matrix[i, i] = scalar
+        }
+
+        return matrix
+    }
+
     public subscript(row: Int, column: Int) -> Scalar {
         get {
             assert(indexIsValidForRow(row, column: column))

--- a/Tests/SurgeTests/MatrixTests.swift
+++ b/Tests/SurgeTests/MatrixTests.swift
@@ -137,6 +137,91 @@ class MatrixTests: XCTestCase {
         XCTAssertEqual(actual, expected)
     }
 
+    func test_init_identity() {
+        let actual: Matrix<Double> = Matrix.identity(size: 3)
+        let expected: Matrix<Double> = [
+            [1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [0.0, 0.0, 1.0],
+        ]
+        XCTAssertEqual(actual, expected)
+    }
+
+    func test_init_eye() {
+        let actual_2x3: Matrix<Double> = Matrix.eye(rows: 2, columns: 3)
+        let expected_2x3: Matrix<Double> = [
+            [1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+        ]
+        XCTAssertEqual(actual_2x3, expected_2x3)
+
+        let actual_3x2: Matrix<Double> = Matrix.eye(rows: 3, columns: 2)
+        let expected_3x2: Matrix<Double> = [
+            [1.0, 0.0],
+            [0.0, 1.0],
+            [0.0, 0.0],
+        ]
+        XCTAssertEqual(actual_3x2, expected_3x2)
+
+        let actual_3x3: Matrix<Double> = Matrix.eye(rows: 3, columns: 3)
+        let expected_3x3: Matrix<Double> = [
+            [1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [0.0, 0.0, 1.0],
+        ]
+        XCTAssertEqual(actual_3x3, expected_3x3)
+    }
+
+    func test_init_diagonal_repeatedValue() {
+        let actual_2x3: Matrix<Double> = Matrix.diagonal(rows: 2, columns: 3, repeatedValue: 42.0)
+        let expected_2x3: Matrix<Double> = [
+            [42.0, 0.0, 0.0],
+            [0.0, 42.0, 0.0],
+        ]
+        XCTAssertEqual(actual_2x3, expected_2x3)
+
+        let actual_3x2: Matrix<Double> = Matrix.diagonal(rows: 3, columns: 2, repeatedValue: 42.0)
+        let expected_3x2: Matrix<Double> = [
+            [42.0, 0.0],
+            [0.0, 42.0],
+            [0.0, 0.0],
+        ]
+        XCTAssertEqual(actual_3x2, expected_3x2)
+
+        let actual_3x3: Matrix<Double> = Matrix.diagonal(rows: 3, columns: 3, repeatedValue: 42.0)
+        let expected_3x3: Matrix<Double> = [
+            [42.0, 0.0, 0.0],
+            [0.0, 42.0, 0.0],
+            [0.0, 0.0, 42.0],
+        ]
+        XCTAssertEqual(actual_3x3, expected_3x3)
+    }
+
+    func test_init_diagonal_scalars() {
+        let actual_2x3: Matrix<Double> = Matrix.diagonal(rows: 2, columns: 3, scalars: [1, 2])
+        let expected_2x3: Matrix<Double> = [
+            [1.0, 0.0, 0.0],
+            [0.0, 2.0, 0.0],
+        ]
+        XCTAssertEqual(actual_2x3, expected_2x3)
+
+        let actual_3x2: Matrix<Double> = Matrix.diagonal(rows: 3, columns: 2, scalars: [1, 2])
+        let expected_3x2: Matrix<Double> = [
+            [1.0, 0.0],
+            [0.0, 2.0],
+            [0.0, 0.0],
+        ]
+        XCTAssertEqual(actual_3x2, expected_3x2)
+
+        let actual_3x3: Matrix<Double> = Matrix.diagonal(rows: 3, columns: 3, scalars: [1, 2, 3])
+        let expected_3x3: Matrix<Double> = [
+            [1.0, 0.0, 0.0],
+            [0.0, 2.0, 0.0],
+            [0.0, 0.0, 3.0],
+        ]
+        XCTAssertEqual(actual_3x3, expected_3x3)
+    }
+
     func test_subscript_row_get() {
         XCTAssertEqual(matrixDouble[row: 0], [1, 2, 3, 4])
         XCTAssertEqual(matrixDouble[row: 1], [5, 6, 7, 8])


### PR DESCRIPTION
Diagonal/eye/identity patterns are common enough for matrix initialization to have them as dedicated initializers.

Depends on https://github.com/mattt/Surge/pull/108