### PR TITLE
In-place all the things! (Vector Edition)

### DIFF
--- a/Sources/Surge/Arithmetic/Arithmetic.swift
+++ b/Sources/Surge/Arithmetic/Arithmetic.swift
@@ -71,11 +71,11 @@ public func +=<L: UnsafeMutableMemoryAccessible>(lhs: inout L, rhs: Double) wher
 // MARK: - Element-wise Addition
 
 public func add<L: UnsafeMemoryAccessible, R: UnsafeMemoryAccessible>(_ lhs: L, _ rhs: R) -> [Float] where L.Element == Float, R.Element == Float {
-    return muladd(lhs, rhs, 1.0)
+    return elmuladd(lhs, rhs, 1.0)
 }
 
 public func add<L: UnsafeMemoryAccessible, R: UnsafeMemoryAccessible>(_ lhs: L, _ rhs: R) -> [Double] where L.Element == Double, R.Element == Double {
-    return muladd(lhs, rhs, 1.0)
+    return elmuladd(lhs, rhs, 1.0)
 }
 
 public func .+ <L: UnsafeMemoryAccessible, R: UnsafeMemoryAccessible>(lhs: L, rhs: R) -> [Float] where L.Element == Float, R.Element == Float {
@@ -88,20 +88,20 @@ public func .+ <L: UnsafeMemoryAccessible, R: UnsafeMemoryAccessible>(lhs: L, rh
 
 // MARK: - Element-wise Addition: In Place
 
-func addInPlace<L: UnsafeMutableMemoryAccessible, R: UnsafeMemoryAccessible>(_ lhs: inout L, _ rhs: R) where L.Element == Float, R.Element == Float {
-    muladdInPlace(&lhs, rhs, 1.0)
+func eladdInPlace<L: UnsafeMutableMemoryAccessible, R: UnsafeMemoryAccessible>(_ lhs: inout L, _ rhs: R) where L.Element == Float, R.Element == Float {
+    elmuladdInPlace(&lhs, rhs, 1.0)
 }
 
-func addInPlace<L: UnsafeMutableMemoryAccessible, R: UnsafeMemoryAccessible>(_ lhs: inout L, _ rhs: R) where L.Element == Double, R.Element == Double {
-    muladdInPlace(&lhs, rhs, 1.0)
+func eladdInPlace<L: UnsafeMutableMemoryAccessible, R: UnsafeMemoryAccessible>(_ lhs: inout L, _ rhs: R) where L.Element == Double, R.Element == Double {
+    elmuladdInPlace(&lhs, rhs, 1.0)
 }
 
 public func .+= <L: UnsafeMutableMemoryAccessible, R: UnsafeMemoryAccessible>(lhs: inout L, rhs: R) where L.Element == Float, R.Element == Float {
-    return addInPlace(&lhs, rhs)
+    return eladdInPlace(&lhs, rhs)
 }
 
 public func .+= <L: UnsafeMutableMemoryAccessible, R: UnsafeMemoryAccessible>(lhs: inout L, rhs: R) where L.Element == Double, R.Element == Double {
-    return addInPlace(&lhs, rhs)
+    return eladdInPlace(&lhs, rhs)
 }
 
 // MARK: - Subtraction
@@ -147,11 +147,11 @@ public func -=<L: UnsafeMutableMemoryAccessible>(lhs: inout L, rhs: Double) wher
 // MARK: - Element-wise Subtraction
 
 public func sub<L: UnsafeMemoryAccessible, R: UnsafeMemoryAccessible>(_ lhs: L, _ rhs: R) -> [Float] where L.Element == Float, R.Element == Float {
-    return muladd(lhs, rhs, -1.0)
+    return elmuladd(lhs, rhs, -1.0)
 }
 
 public func sub<L: UnsafeMemoryAccessible, R: UnsafeMemoryAccessible>(_ lhs: L, _ rhs: R) -> [Double] where L.Element == Double, R.Element == Double {
-    return muladd(lhs, rhs, -1.0)
+    return elmuladd(lhs, rhs, -1.0)
 }
 
 public func .- <L: UnsafeMemoryAccessible, R: UnsafeMemoryAccessible>(lhs: L, rhs: R) -> [Float] where L.Element == Float, R.Element == Float {
@@ -164,39 +164,39 @@ public func .- <L: UnsafeMemoryAccessible, R: UnsafeMemoryAccessible>(lhs: L, rh
 
 // MARK: - Element-wise Subtraction: In Place
 
-func subInPlace<L: UnsafeMutableMemoryAccessible, R: UnsafeMemoryAccessible>(_ lhs: inout L, _ rhs: R) where L.Element == Float, R.Element == Float {
-    muladdInPlace(&lhs, rhs, -1.0)
+func elsubInPlace<L: UnsafeMutableMemoryAccessible, R: UnsafeMemoryAccessible>(_ lhs: inout L, _ rhs: R) where L.Element == Float, R.Element == Float {
+    elmuladdInPlace(&lhs, rhs, -1.0)
 }
 
-func subInPlace<L: UnsafeMutableMemoryAccessible, R: UnsafeMemoryAccessible>(_ lhs: inout L, _ rhs: R) where L.Element == Double, R.Element == Double {
-    muladdInPlace(&lhs, rhs, -1.0)
+func elsubInPlace<L: UnsafeMutableMemoryAccessible, R: UnsafeMemoryAccessible>(_ lhs: inout L, _ rhs: R) where L.Element == Double, R.Element == Double {
+    elmuladdInPlace(&lhs, rhs, -1.0)
 }
 
 public func .-= <L: UnsafeMutableMemoryAccessible, R: UnsafeMemoryAccessible>(lhs: inout L, rhs: R) where L.Element == Float, R.Element == Float {
-    return subInPlace(&lhs, rhs)
+    return elsubInPlace(&lhs, rhs)
 }
 
 public func .-= <L: UnsafeMutableMemoryAccessible, R: UnsafeMemoryAccessible>(lhs: inout L, rhs: R) where L.Element == Double, R.Element == Double {
-    return subInPlace(&lhs, rhs)
+    return elsubInPlace(&lhs, rhs)
 }
 
-// MARK: - Multiply Addition
+// MARK: - Element-wise Multiply Addition
 
-func muladd<L: UnsafeMemoryAccessible, R: UnsafeMemoryAccessible>(_ lhs: L, _ rhs: R, _ alpha: Float) -> [Float] where L.Element == Float, R.Element == Float {
+func elmuladd<L: UnsafeMemoryAccessible, R: UnsafeMemoryAccessible>(_ lhs: L, _ rhs: R, _ alpha: Float) -> [Float] where L.Element == Float, R.Element == Float {
     var results = Array(lhs)
-    muladdInPlace(&results, rhs, alpha)
+    elmuladdInPlace(&results, rhs, alpha)
     return results
 }
 
-func muladd<L: UnsafeMemoryAccessible, R: UnsafeMemoryAccessible>(_ lhs: L, _ rhs: R, _ alpha: Double) -> [Double] where L.Element == Double, R.Element == Double {
+func elmuladd<L: UnsafeMemoryAccessible, R: UnsafeMemoryAccessible>(_ lhs: L, _ rhs: R, _ alpha: Double) -> [Double] where L.Element == Double, R.Element == Double {
     var results = Array(lhs)
-    muladdInPlace(&results, rhs, alpha)
+    elmuladdInPlace(&results, rhs, alpha)
     return results
 }
 
-// MARK: - Multiply Addition: In Place
+// MARK: - Element-wise Multiply Addition: In Place
 
-func muladdInPlace<L: UnsafeMutableMemoryAccessible, R: UnsafeMemoryAccessible>(_ lhs: inout L, _ rhs: R, _ alpha: Float) where L.Element == Float, R.Element == Float {
+func elmuladdInPlace<L: UnsafeMutableMemoryAccessible, R: UnsafeMemoryAccessible>(_ lhs: inout L, _ rhs: R, _ alpha: Float) where L.Element == Float, R.Element == Float {
     precondition(lhs.count == rhs.count, "Collections must have the same size")
     lhs.withUnsafeMutableMemory { lm in
         rhs.withUnsafeMemory { rm in
@@ -205,7 +205,7 @@ func muladdInPlace<L: UnsafeMutableMemoryAccessible, R: UnsafeMemoryAccessible>(
     }
 }
 
-func muladdInPlace<L: UnsafeMutableMemoryAccessible, R: UnsafeMemoryAccessible>(_ lhs: inout L, _ rhs: R, _ alpha: Double) where L.Element == Double, R.Element == Double {
+func elmuladdInPlace<L: UnsafeMutableMemoryAccessible, R: UnsafeMemoryAccessible>(_ lhs: inout L, _ rhs: R, _ alpha: Double) where L.Element == Double, R.Element == Double {
     precondition(lhs.count == rhs.count, "Collections must have the same size")
     lhs.withUnsafeMutableMemory { lm in
         rhs.withUnsafeMemory { rm in
@@ -262,29 +262,29 @@ public func *=<L: UnsafeMutableMemoryAccessible>(lhs: inout L, rhs: Double) wher
 
 // MARK: - Element-wise Multiplication
 
-public func mul<L: UnsafeMemoryAccessible, R: UnsafeMemoryAccessible>(_ lhs: L, _ rhs: R) -> [Float] where L.Element == Float, R.Element == Float {
+public func elmul<L: UnsafeMemoryAccessible, R: UnsafeMemoryAccessible>(_ lhs: L, _ rhs: R) -> [Float] where L.Element == Float, R.Element == Float {
     var results = Array(lhs)
-    mulInPlace(&results, rhs)
+    elmulInPlace(&results, rhs)
     return results
 }
 
-public func mul<L: UnsafeMemoryAccessible, R: UnsafeMemoryAccessible>(_ lhs: L, _ rhs: R) -> [Double] where L.Element == Double, R.Element == Double {
+public func elmul<L: UnsafeMemoryAccessible, R: UnsafeMemoryAccessible>(_ lhs: L, _ rhs: R) -> [Double] where L.Element == Double, R.Element == Double {
     var results = Array(lhs)
-    mulInPlace(&results, rhs)
+    elmulInPlace(&results, rhs)
     return results
 }
 
 public func .* <L: UnsafeMemoryAccessible, R: UnsafeMemoryAccessible>(lhs: L, rhs: R) -> [Float] where L.Element == Float, R.Element == Float {
-    return mul(lhs, rhs)
+    return elmul(lhs, rhs)
 }
 
 public func .* <L: UnsafeMemoryAccessible, R: UnsafeMemoryAccessible>(lhs: L, rhs: R) -> [Double] where L.Element == Double, R.Element == Double {
-    return mul(lhs, rhs)
+    return elmul(lhs, rhs)
 }
 
 // MARK: - Element-wise Multiplication: In Place
 
-func mulInPlace<L: UnsafeMutableMemoryAccessible, R: UnsafeMemoryAccessible>(_ lhs: inout L, _ rhs: R) where L.Element == Float, R.Element == Float {
+func elmulInPlace<L: UnsafeMutableMemoryAccessible, R: UnsafeMemoryAccessible>(_ lhs: inout L, _ rhs: R) where L.Element == Float, R.Element == Float {
     precondition(lhs.count == rhs.count, "Collections must have the same size")
     lhs.withUnsafeMutableMemory { lm in
         rhs.withUnsafeMemory { rm in
@@ -293,7 +293,7 @@ func mulInPlace<L: UnsafeMutableMemoryAccessible, R: UnsafeMemoryAccessible>(_ l
     }
 }
 
-func mulInPlace<L: UnsafeMutableMemoryAccessible, R: UnsafeMemoryAccessible>(_ lhs: inout L, _ rhs: R) where L.Element == Double, R.Element == Double {
+func elmulInPlace<L: UnsafeMutableMemoryAccessible, R: UnsafeMemoryAccessible>(_ lhs: inout L, _ rhs: R) where L.Element == Double, R.Element == Double {
     precondition(lhs.count == rhs.count, "Collections must have the same size")
     lhs.withUnsafeMutableMemory { lm in
         rhs.withUnsafeMemory { rm in
@@ -303,11 +303,11 @@ func mulInPlace<L: UnsafeMutableMemoryAccessible, R: UnsafeMemoryAccessible>(_ l
 }
 
 public func .*= <L: UnsafeMutableMemoryAccessible, R: UnsafeMemoryAccessible>(lhs: inout L, rhs: R) where L.Element == Float, R.Element == Float {
-    return mulInPlace(&lhs, rhs)
+    return elmulInPlace(&lhs, rhs)
 }
 
 public func .*= <L: UnsafeMutableMemoryAccessible, R: UnsafeMemoryAccessible>(lhs: inout L, rhs: R) where L.Element == Double, R.Element == Double {
-    return mulInPlace(&lhs, rhs)
+    return elmulInPlace(&lhs, rhs)
 }
 
 // MARK: - Division
@@ -360,13 +360,13 @@ public func /=<L: UnsafeMutableMemoryAccessible>(lhs: inout L, rhs: Double) wher
 
 public func div<L: UnsafeMemoryAccessible, R: UnsafeMemoryAccessible>(_ lhs: L, _ rhs: R) -> [Float] where L.Element == Float, R.Element == Float {
     var results = Array(lhs)
-    divInPlace(&results, rhs)
+    eldivInPlace(&results, rhs)
     return results
 }
 
 public func div<L: UnsafeMemoryAccessible, R: UnsafeMemoryAccessible>(_ lhs: L, _ rhs: R) -> [Double] where L.Element == Double, R.Element == Double {
     var results = Array(lhs)
-    divInPlace(&results, rhs)
+    eldivInPlace(&results, rhs)
     return results
 }
 
@@ -380,7 +380,7 @@ public func ./ <L: UnsafeMemoryAccessible, R: UnsafeMemoryAccessible>(lhs: L, rh
 
 // MARK: - Element-wise Division: In Place
 
-func divInPlace<L: UnsafeMutableMemoryAccessible, R: UnsafeMemoryAccessible>(_ lhs: inout L, _ rhs: R) where L.Element == Float, R.Element == Float {
+func eldivInPlace<L: UnsafeMutableMemoryAccessible, R: UnsafeMemoryAccessible>(_ lhs: inout L, _ rhs: R) where L.Element == Float, R.Element == Float {
     precondition(lhs.count == rhs.count, "Collections must have the same size")
     lhs.withUnsafeMutableMemory { lm in
         rhs.withUnsafeMemory { rm in
@@ -389,7 +389,7 @@ func divInPlace<L: UnsafeMutableMemoryAccessible, R: UnsafeMemoryAccessible>(_ l
     }
 }
 
-func divInPlace<L: UnsafeMutableMemoryAccessible, R: UnsafeMemoryAccessible>(_ lhs: inout L, _ rhs: R) where L.Element == Double, R.Element == Double {
+func eldivInPlace<L: UnsafeMutableMemoryAccessible, R: UnsafeMemoryAccessible>(_ lhs: inout L, _ rhs: R) where L.Element == Double, R.Element == Double {
     precondition(lhs.count == rhs.count, "Collections must have the same size")
     lhs.withUnsafeMutableMemory { lm in
         rhs.withUnsafeMemory { rm in
@@ -399,11 +399,11 @@ func divInPlace<L: UnsafeMutableMemoryAccessible, R: UnsafeMemoryAccessible>(_ l
 }
 
 public func ./= <L: UnsafeMutableMemoryAccessible, R: UnsafeMemoryAccessible>(lhs: inout L, rhs: R) where L.Element == Float, R.Element == Float {
-    return divInPlace(&lhs, rhs)
+    return eldivInPlace(&lhs, rhs)
 }
 
 public func ./= <L: UnsafeMutableMemoryAccessible, R: UnsafeMemoryAccessible>(lhs: inout L, rhs: R) where L.Element == Double, R.Element == Double {
-    return divInPlace(&lhs, rhs)
+    return eldivInPlace(&lhs, rhs)
 }
 
 // MARK: - Modulo

--- a/Sources/Surge/Linear Algebra/Scalar.swift
+++ b/Sources/Surge/Linear Algebra/Scalar.swift
@@ -23,11 +23,15 @@ import Accelerate
 // MARK: - Multiplication
 
 public func mul<R: UnsafeMemoryAccessible>(_ lhs: Float, _ rhs: R) -> [Float] where R.Element == Float {
-    return mul([Float](repeating: lhs, count: numericCast(rhs.count)), rhs)
+    var results = [Float](repeating: lhs, count: numericCast(rhs.count))
+    elmulInPlace(&results, rhs)
+    return results
 }
 
 public func mul<R: UnsafeMemoryAccessible>(_ lhs: Double, _ rhs: R) -> [Double] where R.Element == Double {
-    return mul([Double](repeating: lhs, count: numericCast(rhs.count)), rhs)
+    var results = [Double](repeating: lhs, count: numericCast(rhs.count))
+    elmulInPlace(&results, rhs)
+    return results
 }
 
 public func * <R: UnsafeMemoryAccessible>(lhs: Float, rhs: R) -> [Float] where R.Element == Float {

--- a/Tests/SurgeTests/ArithmeticTests.swift
+++ b/Tests/SurgeTests/ArithmeticTests.swift
@@ -35,7 +35,7 @@ class ArithmeticTests: XCTestCase {
         let rhs: [Scalar] = .monotonicNormalized()
 
         var actual: [Scalar] = lhs
-        Surge.addInPlace(&actual, rhs)
+        Surge.eladdInPlace(&actual, rhs)
 
         let expected = Swift.zip(lhs, rhs).map { $0 + $1 }
 
@@ -49,7 +49,7 @@ class ArithmeticTests: XCTestCase {
         let rhs: [Scalar] = .monotonicNormalized()
 
         var actual: [Scalar] = lhs
-        Surge.addInPlace(&actual, rhs)
+        Surge.eladdInPlace(&actual, rhs)
 
         let expected = Swift.zip(lhs, rhs).map { $0 + $1 }
 
@@ -65,7 +65,7 @@ class ArithmeticTests: XCTestCase {
         let rhs: [Scalar] = .monotonicNormalized()
 
         var actual: [Scalar] = lhs
-        Surge.subInPlace(&actual, rhs)
+        Surge.elsubInPlace(&actual, rhs)
 
         let expected = Swift.zip(lhs, rhs).map { $0 - $1 }
 
@@ -79,7 +79,7 @@ class ArithmeticTests: XCTestCase {
         let rhs: [Scalar] = .monotonicNormalized()
 
         var actual: [Scalar] = lhs
-        Surge.subInPlace(&actual, rhs)
+        Surge.elsubInPlace(&actual, rhs)
 
         let expected = Swift.zip(lhs, rhs).map { $0 - $1 }
 
@@ -95,7 +95,7 @@ class ArithmeticTests: XCTestCase {
         let rhs: [Scalar] = .monotonicNormalized()
 
         var actual: [Scalar] = lhs
-        Surge.mulInPlace(&actual, rhs)
+        Surge.elmulInPlace(&actual, rhs)
 
         let expected = Swift.zip(lhs, rhs).map { $0 * $1 }
 
@@ -109,7 +109,7 @@ class ArithmeticTests: XCTestCase {
         let rhs: [Scalar] = .monotonicNormalized()
 
         var actual: [Scalar] = lhs
-        Surge.mulInPlace(&actual, rhs)
+        Surge.elmulInPlace(&actual, rhs)
 
         let expected = Swift.zip(lhs, rhs).map { $0 * $1 }
 
@@ -125,7 +125,7 @@ class ArithmeticTests: XCTestCase {
         let rhs: [Scalar] = .monotonicNormalized()
 
         var actual: [Scalar] = lhs
-        Surge.divInPlace(&actual, rhs)
+        Surge.eldivInPlace(&actual, rhs)
 
         let expected = Swift.zip(lhs, rhs).map { $0 / $1 }
 
@@ -139,7 +139,7 @@ class ArithmeticTests: XCTestCase {
         let rhs: [Scalar] = .monotonicNormalized()
 
         var actual: [Scalar] = lhs
-        Surge.divInPlace(&actual, rhs)
+        Surge.eldivInPlace(&actual, rhs)
 
         let expected = Swift.zip(lhs, rhs).map { $0 / $1 }
 

--- a/Tests/SurgeTests/VectorTests.swift
+++ b/Tests/SurgeTests/VectorTests.swift
@@ -18,8 +18,9 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-@testable import Surge
 import XCTest
+
+@testable import Surge
 
 // swiftlint:disable nesting type_body_length
 
@@ -29,78 +30,6 @@ class VectorTests: XCTestCase {
     func test_init() {
         let v = Vector([1.0, 2.0])
         XCTAssertEqual(v.scalars, [1.0, 2.0])
-    }
-
-    // MARK: - Subscript
-
-    func test_subscript() {
-        typealias Scalar = Double
-
-        let vector: Vector<Scalar> = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-
-        XCTAssertEqual(vector[0], 1)
-        XCTAssertEqual(vector[2], 3)
-        XCTAssertEqual(vector[9], 10)
-    }
-
-    // MARK: - Addition
-
-    func test_add_vector_vector_double() {
-        typealias Scalar = Double
-
-        let vector: Vector<Scalar> = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-
-        var actual: Vector<Scalar> = []
-        measure {
-            actual = vector + vector
-        }
-        let expected: Vector<Scalar> = [2, 4, 6, 8, 10, 12, 14, 16, 18, 20]
-
-        XCTAssertEqual(actual, expected, accuracy: 1e-8)
-    }
-
-    func test_add_vector_vector_float() {
-        typealias Scalar = Float
-
-        let vector: Vector<Scalar> = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-
-        var actual: Vector<Scalar> = []
-        measure {
-            actual = vector + vector
-        }
-        let expected: Vector<Scalar> = [2, 4, 6, 8, 10, 12, 14, 16, 18, 20]
-
-        XCTAssertEqual(actual, expected, accuracy: 1e-8)
-    }
-
-    func test_add_vector_scalar_double() {
-        typealias Scalar = Double
-
-        let vector: Vector<Scalar> = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-        let scalar: Scalar = 1.0
-
-        var actual: Vector<Scalar> = []
-        measure {
-            actual = vector + scalar
-        }
-        let expected: Vector<Scalar> = [2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
-
-        XCTAssertEqual(actual, expected, accuracy: 1e-8)
-    }
-
-    func test_add_vector_scalar_float() {
-        typealias Scalar = Float
-
-        let vector: Vector<Scalar> = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-        let scalar: Scalar = 1.0
-
-        var actual: Vector<Scalar> = []
-        measure {
-            actual = vector + scalar
-        }
-        let expected: Vector<Scalar> = [2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
-
-        XCTAssertEqual(actual, expected, accuracy: 1e-8)
     }
 
     // MARK: - Addition: In Place
@@ -179,66 +108,6 @@ class VectorTests: XCTestCase {
         }
 
         let expected: Vector<Scalar> = [2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
-
-        XCTAssertEqual(actual, expected, accuracy: 1e-8)
-    }
-
-    // MARK: - Subtraction
-
-    func test_sub_vector_vector_double() {
-        typealias Scalar = Double
-
-        let vector: Vector<Scalar> = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-
-        var actual: Vector<Scalar> = []
-        measure {
-            actual = vector - vector
-        }
-        let expected: Vector<Scalar> = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
-
-        XCTAssertEqual(actual, expected, accuracy: 1e-8)
-    }
-
-    func test_sub_vector_vector_float() {
-        typealias Scalar = Float
-
-        let vector: Vector<Scalar> = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-
-        var actual: Vector<Scalar> = []
-        measure {
-            actual = vector - vector
-        }
-        let expected: Vector<Scalar> = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
-
-        XCTAssertEqual(actual, expected, accuracy: 1e-8)
-    }
-
-    func test_sub_vector_scalar_double() {
-        typealias Scalar = Double
-
-        let vector: Vector<Scalar> = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-        let scalar: Scalar = 1.0
-
-        var actual: Vector<Scalar> = []
-        measure {
-            actual = vector - scalar
-        }
-        let expected: Vector<Scalar> = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
-
-        XCTAssertEqual(actual, expected, accuracy: 1e-8)
-    }
-
-    func test_sub_vector_scalar_float() {
-        typealias Scalar = Float
-
-        let vector: Vector<Scalar> = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-        let scalar: Scalar = 1.0
-
-        var actual: Vector<Scalar> = []
-        measure {
-            actual = vector - scalar
-        }
-        let expected: Vector<Scalar> = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 
         XCTAssertEqual(actual, expected, accuracy: 1e-8)
     }
@@ -323,38 +192,6 @@ class VectorTests: XCTestCase {
         XCTAssertEqual(actual, expected, accuracy: 1e-8)
     }
 
-    // MARK: - Multiply Addition
-
-    func test_muladd_vector_vector_double() {
-        typealias Scalar = Double
-
-        let vector: Vector<Scalar> = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-        let scalar: Scalar = 2.0
-
-        var actual: Vector<Scalar> = []
-        measure {
-            actual = Surge.muladd(vector, vector, scalar)
-        }
-        let expected: Vector<Scalar> = [3, 6, 9, 12, 15, 18, 21, 24, 27, 30]
-
-        XCTAssertEqual(actual, expected, accuracy: 1e-8)
-    }
-
-    func test_muladd_vector_vector_float() {
-        typealias Scalar = Float
-
-        let vector: Vector<Scalar> = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-        let scalar: Scalar = 2.0
-
-        var actual: Vector<Scalar> = []
-        measure {
-            actual = Surge.muladd(vector, vector, scalar)
-        }
-        let expected: Vector<Scalar> = [3, 6, 9, 12, 15, 18, 21, 24, 27, 30]
-
-        XCTAssertEqual(actual, expected, accuracy: 1e-8)
-    }
-
     // MARK: - Multiply Addition: In Place
 
     func test_muladd_in_place_vector_vector_double() {
@@ -395,78 +232,6 @@ class VectorTests: XCTestCase {
         let expected: Vector<Scalar> = [3, 6, 9, 12, 15, 18, 21, 24, 27, 30]
 
         XCTAssertEqual(actual, expected, accuracy: 1e-8)
-    }
-
-    // MARK: - Multiplication
-
-    func test_mul_vector_scalar_double() {
-        typealias Scalar = Double
-
-        let vector: Vector<Scalar> = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-        let scalar: Scalar = 2.0
-
-        var actual: Vector<Scalar> = []
-        measure {
-            actual = vector * scalar
-        }
-        let expected: Vector<Scalar> = [2, 4, 6, 8, 10, 12, 14, 16, 18, 20]
-
-        XCTAssertEqual(actual, expected, accuracy: 1e-8)
-    }
-
-    func test_mul_vector_scalar_float() {
-        typealias Scalar = Float
-
-        let vector: Vector<Scalar> = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-        let scalar: Scalar = 2.0
-
-        var actual: Vector<Scalar> = []
-        measure {
-            actual = vector * scalar
-        }
-        let expected: Vector<Scalar> = [2, 4, 6, 8, 10, 12, 14, 16, 18, 20]
-
-        XCTAssertEqual(actual, expected, accuracy: 1e-8)
-    }
-
-    func test_mul_vector_matrix_float() {
-        typealias Scalar = Float
-
-        let lhs: Vector<Scalar> = [1, 2, 4]
-
-        let rhs: Matrix<Scalar> = [
-            [1, 4],
-            [2, 5],
-            [3, 6],
-        ]
-
-        var actual: Vector<Scalar> = []
-        measure {
-            actual = lhs * rhs
-        }
-        let expected: Vector<Scalar> = [17, 38]
-
-        XCTAssertEqual(actual, expected)
-    }
-
-    func test_mul_vector_matrix_double() {
-        typealias Scalar = Double
-
-        let lhs: Vector<Scalar> = [1, 2, 4]
-
-        let rhs: Matrix<Scalar> = [
-            [1, 4],
-            [2, 5],
-            [3, 6],
-        ]
-
-        var actual: Vector<Scalar> = []
-        measure {
-            actual = lhs * rhs
-        }
-        let expected: Vector<Scalar> = [17, 38]
-
-        XCTAssertEqual(actual, expected)
     }
 
     // MARK: - Multiplication: In Place
@@ -511,38 +276,6 @@ class VectorTests: XCTestCase {
         XCTAssertEqual(actual, expected, accuracy: 1e-8)
     }
 
-    // MARK: - Division
-
-    func test_div_vector_scalar_double() {
-        typealias Scalar = Double
-
-        let vector: Vector<Scalar> = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-        let scalar: Scalar = 0.5
-
-        var actual: Vector<Scalar> = []
-        measure {
-            actual = vector / scalar
-        }
-        let expected: Vector<Scalar> = [2, 4, 6, 8, 10, 12, 14, 16, 18, 20]
-
-        XCTAssertEqual(actual, expected, accuracy: 1e-8)
-    }
-
-    func test_div_vector_scalar_float() {
-        typealias Scalar = Float
-
-        let vector: Vector<Scalar> = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-        let scalar: Scalar = 0.5
-
-        var actual: Vector<Scalar> = []
-        measure {
-            actual = vector / scalar
-        }
-        let expected: Vector<Scalar> = [2, 4, 6, 8, 10, 12, 14, 16, 18, 20]
-
-        XCTAssertEqual(actual, expected, accuracy: 1e-5)
-    }
-
     // MARK: - Division: In Place
 
     func test_div_in_place_vector_scalar_double() {
@@ -585,36 +318,6 @@ class VectorTests: XCTestCase {
         XCTAssertEqual(actual, expected, accuracy: 1e-5)
     }
 
-    // MARK: - Element-wise Multiplication
-
-    func test_elmul_double() {
-        typealias Scalar = Double
-
-        let vector: Vector<Scalar> = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-
-        var actual: Vector<Scalar> = []
-        measure {
-            actual = vector .* vector
-        }
-        let expected: Vector<Scalar> = [1, 4, 9, 16, 25, 36, 49, 64, 81, 100]
-
-        XCTAssertEqual(actual, expected, accuracy: 1e-8)
-    }
-
-    func test_elmul_float() {
-        typealias Scalar = Float
-
-        let vector: Vector<Scalar> = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-
-        var actual: Vector<Scalar> = []
-        measure {
-            actual = vector .* vector
-        }
-        let expected: Vector<Scalar> = [1, 4, 9, 16, 25, 36, 49, 64, 81, 100]
-
-        XCTAssertEqual(actual, expected, accuracy: 1e-8)
-    }
-
     // MARK: - Element-wise Multiplication: In Place
 
     func test_elmul_in_place_double() {
@@ -653,36 +356,6 @@ class VectorTests: XCTestCase {
         let expected: Vector<Scalar> = [1, 4, 9, 16, 25, 36, 49, 64, 81, 100]
 
         XCTAssertEqual(actual, expected, accuracy: 1e-8)
-    }
-
-    // MARK: - Element-wise Division
-
-    func test_eldiv_double() {
-        typealias Scalar = Double
-
-        let vector: Vector<Scalar> = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-
-        var actual: Vector<Scalar> = []
-        measure {
-            actual = vector ./ vector
-        }
-        let expected: Vector<Scalar> = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
-
-        XCTAssertEqual(actual, expected, accuracy: 1e-8)
-    }
-
-    func test_eldiv_float() {
-        typealias Scalar = Float
-
-        let vector: Vector<Scalar> = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-
-        var actual: Vector<Scalar> = []
-        measure {
-            actual = vector ./ vector
-        }
-        let expected: Vector<Scalar> = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
-
-        XCTAssertEqual(actual, expected, accuracy: 1e-6)
     }
 
     // MARK: - Element-wise Division: In Place
@@ -751,28 +424,38 @@ class VectorTests: XCTestCase {
 
     // MARK: - Power
 
-    func test_pow_vector_scalar_double() {
+    func test_pow_in_place_vector_scalar_double() {
         typealias Scalar = Double
 
         let vector: Vector<Scalar> = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        let scalar: Scalar = 2.0
 
         var actual: Vector<Scalar> = []
-        measure {
-            actual = pow(vector, 2)
+        measureMetrics([.wallClockTime], automaticallyStartMeasuring: false) {
+            actual = vector
+
+            startMeasuring()
+            powInPlace(&actual, scalar)
+            stopMeasuring()
         }
         let expected: Vector<Scalar> = [1, 4, 9, 16, 25, 36, 49, 64, 81, 100]
 
         XCTAssertEqual(actual, expected, accuracy: 1e-8)
     }
 
-    func test_pow_vector_scalar_float() {
+    func test_pow_in_place_vector_scalar_float() {
         typealias Scalar = Float
 
         let vector: Vector<Scalar> = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        let scalar: Scalar = 2.0
 
         var actual: Vector<Scalar> = []
-        measure {
-            actual = pow(vector, 2)
+        measureMetrics([.wallClockTime], automaticallyStartMeasuring: false) {
+            actual = vector
+
+            startMeasuring()
+            powInPlace(&actual, scalar)
+            stopMeasuring()
         }
         let expected: Vector<Scalar> = [1, 4, 9, 16, 25, 36, 49, 64, 81, 100]
 
@@ -781,14 +464,18 @@ class VectorTests: XCTestCase {
 
     // MARK: - Exponential
 
-    func test_exp_vector_double() {
+    func test_exp_in_place_vector_double() {
         typealias Scalar = Double
 
         let vector: Vector<Scalar> = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
 
         var actual: Vector<Scalar> = []
-        measure {
-            actual = exp(vector)
+        measureMetrics([.wallClockTime], automaticallyStartMeasuring: false) {
+            actual = vector
+
+            startMeasuring()
+            expInPlace(&actual)
+            stopMeasuring()
         }
         let expected: Vector<Scalar> = [
             2.718_282, 7.389_056, 20.085_537, 54.598_150, 148.413_159,
@@ -798,14 +485,18 @@ class VectorTests: XCTestCase {
         XCTAssertEqual(actual, expected, accuracy: 1e-6)
     }
 
-    func test_exp_vector_float() {
+    func test_exp_in_place_vector_float() {
         typealias Scalar = Float
 
         let vector: Vector<Scalar> = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
 
         var actual: Vector<Scalar> = []
-        measure {
-            actual = exp(vector)
+        measureMetrics([.wallClockTime], automaticallyStartMeasuring: false) {
+            actual = vector
+
+            startMeasuring()
+            expInPlace(&actual)
+            stopMeasuring()
         }
         let expected: Vector<Scalar> = [
             2.718_282, 7.389_056, 20.085_537, 54.598_150, 148.413_159,


### PR DESCRIPTION
Similar to #119 this PR adds `…InPlace` variants for existing functions on `Vector<Scalar>`, turning the latter into thin wrappers around the former. As such most comments from #119 also apply to this one.

Depends on #123