### PR TITLE
Improved vector tests; removed redundant benchmarks

### DIFF
--- a/Sources/Surge/Linear Algebra/Matrix.swift
+++ b/Sources/Surge/Linear Algebra/Matrix.swift
@@ -75,7 +75,7 @@ public struct Matrix<Scalar> where Scalar: FloatingPoint, Scalar: ExpressibleByF
 
     public static func diagonal(rows: Int, columns: Int, repeatedValue: Scalar) -> Matrix<Scalar> {
         let count = Swift.min(rows, columns)
-        let scalars = Swift.repeatElement(repeatedValue, count: count)
+        let scalars = repeatElement(repeatedValue, count: count)
         return self.diagonal(rows: rows, columns: columns, scalars: scalars)
     }
 

--- a/Tests/SurgeTests/ArithmeticTests.swift
+++ b/Tests/SurgeTests/ArithmeticTests.swift
@@ -37,7 +37,7 @@ class ArithmeticTests: XCTestCase {
         var actual: [Scalar] = lhs
         Surge.eladdInPlace(&actual, rhs)
 
-        let expected = Swift.zip(lhs, rhs).map { $0 + $1 }
+        let expected = zip(lhs, rhs).map { $0 + $1 }
 
         XCTAssertEqual(actual, expected, accuracy: 1e-8)
     }
@@ -51,7 +51,7 @@ class ArithmeticTests: XCTestCase {
         var actual: [Scalar] = lhs
         Surge.eladdInPlace(&actual, rhs)
 
-        let expected = Swift.zip(lhs, rhs).map { $0 + $1 }
+        let expected = zip(lhs, rhs).map { $0 + $1 }
 
         XCTAssertEqual(actual, expected, accuracy: 1e-8)
     }
@@ -67,7 +67,7 @@ class ArithmeticTests: XCTestCase {
         var actual: [Scalar] = lhs
         Surge.elsubInPlace(&actual, rhs)
 
-        let expected = Swift.zip(lhs, rhs).map { $0 - $1 }
+        let expected = zip(lhs, rhs).map { $0 - $1 }
 
         XCTAssertEqual(actual, expected, accuracy: 1e-8)
     }
@@ -81,7 +81,7 @@ class ArithmeticTests: XCTestCase {
         var actual: [Scalar] = lhs
         Surge.elsubInPlace(&actual, rhs)
 
-        let expected = Swift.zip(lhs, rhs).map { $0 - $1 }
+        let expected = zip(lhs, rhs).map { $0 - $1 }
 
         XCTAssertEqual(actual, expected, accuracy: 1e-8)
     }
@@ -97,7 +97,7 @@ class ArithmeticTests: XCTestCase {
         var actual: [Scalar] = lhs
         Surge.elmulInPlace(&actual, rhs)
 
-        let expected = Swift.zip(lhs, rhs).map { $0 * $1 }
+        let expected = zip(lhs, rhs).map { $0 * $1 }
 
         XCTAssertEqual(actual, expected, accuracy: 1e-8)
     }
@@ -111,7 +111,7 @@ class ArithmeticTests: XCTestCase {
         var actual: [Scalar] = lhs
         Surge.elmulInPlace(&actual, rhs)
 
-        let expected = Swift.zip(lhs, rhs).map { $0 * $1 }
+        let expected = zip(lhs, rhs).map { $0 * $1 }
 
         XCTAssertEqual(actual, expected, accuracy: 1e-8)
     }
@@ -127,7 +127,7 @@ class ArithmeticTests: XCTestCase {
         var actual: [Scalar] = lhs
         Surge.eldivInPlace(&actual, rhs)
 
-        let expected = Swift.zip(lhs, rhs).map { $0 / $1 }
+        let expected = zip(lhs, rhs).map { $0 / $1 }
 
         XCTAssertEqual(actual, expected, accuracy: 1e-6)
     }
@@ -141,7 +141,7 @@ class ArithmeticTests: XCTestCase {
         var actual: [Scalar] = lhs
         Surge.eldivInPlace(&actual, rhs)
 
-        let expected = Swift.zip(lhs, rhs).map { $0 / $1 }
+        let expected = zip(lhs, rhs).map { $0 / $1 }
 
         XCTAssertEqual(actual, expected, accuracy: 1e-8)
     }
@@ -157,7 +157,7 @@ class ArithmeticTests: XCTestCase {
         var actual: [Scalar] = lhs
         Surge.modInPlace(&actual, rhs)
 
-        let expected = Swift.zip(lhs, rhs).map { fmod($0, $1) }
+        let expected = zip(lhs, rhs).map { fmod($0, $1) }
 
         XCTAssertEqual(actual, expected, accuracy: 1e-8)
     }
@@ -171,7 +171,7 @@ class ArithmeticTests: XCTestCase {
         var actual: [Scalar] = lhs
         Surge.modInPlace(&actual, rhs)
 
-        let expected = Swift.zip(lhs, rhs).map { fmod($0, $1) }
+        let expected = zip(lhs, rhs).map { fmod($0, $1) }
 
         XCTAssertEqual(actual, expected, accuracy: 1e-8)
     }
@@ -187,7 +187,7 @@ class ArithmeticTests: XCTestCase {
         var actual: [Scalar] = lhs
         Surge.remainderInPlace(&actual, rhs)
 
-        let expected = Swift.zip(lhs, rhs).map { remainder($0, $1) }
+        let expected = zip(lhs, rhs).map { remainder($0, $1) }
 
         XCTAssertEqual(actual, expected, accuracy: 1e-8)
     }
@@ -201,7 +201,7 @@ class ArithmeticTests: XCTestCase {
         var actual: [Scalar] = lhs
         Surge.remainderInPlace(&actual, rhs)
 
-        let expected = Swift.zip(lhs, rhs).map { remainder($0, $1) }
+        let expected = zip(lhs, rhs).map { remainder($0, $1) }
 
         XCTAssertEqual(actual, expected, accuracy: 1e-8)
     }
@@ -273,7 +273,7 @@ class ArithmeticTests: XCTestCase {
         var actual: [Scalar] = lhs
         Surge.powInPlace(&actual, rhs)
 
-        let expected = Swift.zip(lhs, rhs).map { pow($0, $1) }
+        let expected = zip(lhs, rhs).map { pow($0, $1) }
 
         XCTAssertEqual(actual, expected, accuracy: 1e-5)
     }
@@ -287,7 +287,7 @@ class ArithmeticTests: XCTestCase {
         var actual: [Scalar] = lhs
         Surge.powInPlace(&actual, rhs)
 
-        let expected = Swift.zip(lhs, rhs).map { pow($0, $1) }
+        let expected = zip(lhs, rhs).map { pow($0, $1) }
 
         XCTAssertEqual(actual, expected, accuracy: 1e-8)
     }
@@ -386,7 +386,7 @@ class ArithmeticTests: XCTestCase {
 
         let actual: Scalar = Surge.dot(lhs, rhs)
 
-        let expected = Swift.zip(lhs, rhs).reduce(0) { $0 + ($1.0 * $1.1) }
+        let expected = zip(lhs, rhs).reduce(0) { $0 + ($1.0 * $1.1) }
 
         XCTAssertEqual(actual, expected, accuracy: 1e-1)
     }
@@ -399,7 +399,7 @@ class ArithmeticTests: XCTestCase {
 
         let actual: Scalar = Surge.dot(lhs, rhs)
 
-        let expected = Swift.zip(lhs, rhs).reduce(0) { $0 + ($1.0 * $1.1) }
+        let expected = zip(lhs, rhs).reduce(0) { $0 + ($1.0 * $1.1) }
 
         XCTAssertEqual(actual, expected, accuracy: 1e-8)
     }
@@ -440,7 +440,7 @@ class ArithmeticTests: XCTestCase {
 
         let actual: Scalar = Surge.dist(lhs, rhs)
 
-        let expected: Scalar = sqrt(Swift.zip(lhs, rhs).map({ $0 - $1 }).map({ $0 * $0 }).reduce(0.0, +))
+        let expected: Scalar = sqrt(zip(lhs, rhs).map({ $0 - $1 }).map({ $0 * $0 }).reduce(0.0, +))
 
         XCTAssertEqual(actual, expected, accuracy: 1e-6)
     }
@@ -453,7 +453,7 @@ class ArithmeticTests: XCTestCase {
 
         let actual: Scalar = Surge.dist(lhs, rhs)
 
-        let expected: Scalar = sqrt(Swift.zip(lhs, rhs).map({ $0 - $1 }).map({ $0 * $0 }).reduce(0.0, +))
+        let expected: Scalar = sqrt(zip(lhs, rhs).map({ $0 - $1 }).map({ $0 * $0 }).reduce(0.0, +))
 
         XCTAssertEqual(actual, expected, accuracy: 1e-6)
     }
@@ -468,7 +468,7 @@ class ArithmeticTests: XCTestCase {
 
         let actual: Scalar = Surge.distSq(lhs, rhs)
 
-        let partialDistances: [Scalar] = Swift.zip(lhs, rhs).map { $0 - $1 }
+        let partialDistances: [Scalar] = zip(lhs, rhs).map { $0 - $1 }
         let partialDistancesSquared: [Scalar] = partialDistances.map { $0 * $0 }
         let expected: Scalar = partialDistancesSquared.reduce(0.0, +)
 
@@ -483,7 +483,7 @@ class ArithmeticTests: XCTestCase {
 
         let actual: Scalar = Surge.distSq(lhs, rhs)
 
-        let partialDistances: [Scalar] = Swift.zip(lhs, rhs).map { $0 - $1 }
+        let partialDistances: [Scalar] = zip(lhs, rhs).map { $0 - $1 }
         let partialDistancesSquared: [Scalar] = partialDistances.map { $0 * $0 }
         let expected: Scalar = partialDistancesSquared.reduce(0.0, +)
 

--- a/Tests/SurgeTests/VectorTests.swift
+++ b/Tests/SurgeTests/VectorTests.swift
@@ -60,7 +60,7 @@ class VectorTests: XCTestCase {
         var actual: Vector<Scalar> = lhs
         Surge.addInPlace(&actual, rhs)
 
-        let expected: Vector<Scalar> = Vector(Swift.zip(lhs, rhs).map { $0 + $1 })
+        let expected: Vector<Scalar> = Vector(zip(lhs, rhs).map { $0 + $1 })
 
         XCTAssertEqual(actual, expected, accuracy: 1e-8)
     }
@@ -74,7 +74,7 @@ class VectorTests: XCTestCase {
         var actual: Vector<Scalar> = lhs
         Surge.addInPlace(&actual, rhs)
 
-        let expected: Vector<Scalar> = Vector(Swift.zip(lhs, rhs).map { $0 + $1 })
+        let expected: Vector<Scalar> = Vector(zip(lhs, rhs).map { $0 + $1 })
 
         XCTAssertEqual(actual, expected, accuracy: 1e-8)
     }
@@ -118,7 +118,7 @@ class VectorTests: XCTestCase {
         var actual: Vector<Scalar> = lhs
         Surge.subInPlace(&actual, rhs)
 
-        let expected: Vector<Scalar> = Vector(Swift.zip(lhs, rhs).map { $0 - $1 })
+        let expected: Vector<Scalar> = Vector(zip(lhs, rhs).map { $0 - $1 })
 
         XCTAssertEqual(actual, expected, accuracy: 1e-8)
     }
@@ -132,7 +132,7 @@ class VectorTests: XCTestCase {
         var actual: Vector<Scalar> = lhs
         Surge.subInPlace(&actual, rhs)
 
-        let expected: Vector<Scalar> = Vector(Swift.zip(lhs, rhs).map { $0 - $1 })
+        let expected: Vector<Scalar> = Vector(zip(lhs, rhs).map { $0 - $1 })
 
         XCTAssertEqual(actual, expected, accuracy: 1e-8)
     }
@@ -177,7 +177,7 @@ class VectorTests: XCTestCase {
         var actual: Vector<Scalar> = lhs
         Surge.muladdInPlace(&actual, rhs, alpha)
 
-        let expected: Vector<Scalar> = Vector(Swift.zip(lhs.scalars, rhs.scalars).map { $0 + ($1 * alpha) })
+        let expected: Vector<Scalar> = Vector(zip(lhs.scalars, rhs.scalars).map { $0 + ($1 * alpha) })
 
         XCTAssertEqual(actual, expected, accuracy: 1e-8)
     }
@@ -192,7 +192,7 @@ class VectorTests: XCTestCase {
         var actual: Vector<Scalar> = lhs
         Surge.muladdInPlace(&actual, rhs, alpha)
 
-        let expected: Vector<Scalar> = Vector(Swift.zip(lhs.scalars, rhs.scalars).map { $0 + ($1 * alpha) })
+        let expected: Vector<Scalar> = Vector(zip(lhs.scalars, rhs.scalars).map { $0 + ($1 * alpha) })
 
         XCTAssertEqual(actual, expected, accuracy: 1e-6)
     }
@@ -238,7 +238,7 @@ class VectorTests: XCTestCase {
         let transposed: Matrix<Scalar> = Surge.transpose(rhs)
         let columns: [Vector<Scalar>] = transposed.map { Vector($0) }
         let expected: Vector<Scalar> = Vector(columns.map { rhs in
-            let squares: [Scalar] = Swift.zip(lhs, rhs).map { $0 * $1 }
+            let squares: [Scalar] = zip(lhs, rhs).map { $0 * $1 }
             return squares.reduce(0.0, +)
         })
 
@@ -256,7 +256,7 @@ class VectorTests: XCTestCase {
         let transposed: Matrix<Scalar> = Surge.transpose(rhs)
         let columns: [Vector<Scalar>] = transposed.map { Vector($0) }
         let expected: Vector<Scalar> = Vector(columns.map { rhs in
-            let squares: [Scalar] = Swift.zip(lhs, rhs).map { $0 * $1 }
+            let squares: [Scalar] = zip(lhs, rhs).map { $0 * $1 }
             return squares.reduce(0.0, +)
         })
 
@@ -304,7 +304,7 @@ class VectorTests: XCTestCase {
         var actual: Vector<Scalar> = lhs
         Surge.elmulInPlace(&actual, rhs)
 
-        let expected: Vector<Scalar> = Vector(Swift.zip(lhs, rhs).map { $0 * $1 })
+        let expected: Vector<Scalar> = Vector(zip(lhs, rhs).map { $0 * $1 })
 
         XCTAssertEqual(actual, expected, accuracy: 1e-8)
     }
@@ -318,7 +318,7 @@ class VectorTests: XCTestCase {
         var actual: Vector<Scalar> = lhs
         Surge.elmulInPlace(&actual, rhs)
 
-        let expected: Vector<Scalar> = Vector(Swift.zip(lhs, rhs).map { $0 * $1 })
+        let expected: Vector<Scalar> = Vector(zip(lhs, rhs).map { $0 * $1 })
 
         XCTAssertEqual(actual, expected, accuracy: 1e-8)
     }
@@ -334,7 +334,7 @@ class VectorTests: XCTestCase {
         var actual: Vector<Scalar> = lhs
         Surge.eldivInPlace(&actual, rhs)
 
-        let expected: Vector<Scalar> = Vector(Swift.zip(lhs, rhs).map { $0 / $1 })
+        let expected: Vector<Scalar> = Vector(zip(lhs, rhs).map { $0 / $1 })
 
         XCTAssertEqual(actual, expected, accuracy: 1e-8)
     }
@@ -348,7 +348,7 @@ class VectorTests: XCTestCase {
         var actual: Vector<Scalar> = lhs
         Surge.eldivInPlace(&actual, rhs)
 
-        let expected: Vector<Scalar> = Vector(Swift.zip(lhs, rhs).map { $0 / $1 })
+        let expected: Vector<Scalar> = Vector(zip(lhs, rhs).map { $0 / $1 })
 
         XCTAssertEqual(actual, expected, accuracy: 1e-6)
     }
@@ -363,7 +363,7 @@ class VectorTests: XCTestCase {
 
         let actual: Scalar = Surge.dot(lhs, rhs)
 
-        let squares: [Scalar] = Swift.zip(lhs, rhs).map { $0 * $1 }
+        let squares: [Scalar] = zip(lhs, rhs).map { $0 * $1 }
         let expected: Scalar = squares.reduce(0.0, +)
 
         XCTAssertEqual(actual, expected, accuracy: 1e-8)
@@ -377,7 +377,7 @@ class VectorTests: XCTestCase {
 
         let actual: Scalar = Surge.dot(lhs, rhs)
 
-        let squares: [Scalar] = Swift.zip(lhs, rhs).map { $0 * $1 }
+        let squares: [Scalar] = zip(lhs, rhs).map { $0 * $1 }
         let expected: Scalar = squares.reduce(0.0, +)
 
         XCTAssertEqual(actual, expected, accuracy: 1e-3)
@@ -451,7 +451,7 @@ class VectorTests: XCTestCase {
 
         let actual: Scalar = Surge.dist(lhs, rhs)
 
-        let partialDistances: [Scalar] = Swift.zip(lhs, rhs).map { $0 - $1 }
+        let partialDistances: [Scalar] = zip(lhs, rhs).map { $0 - $1 }
         let partialDistancesSquared: [Scalar] = partialDistances.map { $0 * $0 }
         let sumOfPartialDistancesSquared: Scalar = partialDistancesSquared.reduce(0.0, +)
         let expected: Scalar = sqrt(sumOfPartialDistancesSquared)
@@ -467,7 +467,7 @@ class VectorTests: XCTestCase {
 
         let actual: Scalar = Surge.dist(lhs, rhs)
 
-        let partialDistances: [Scalar] = Swift.zip(lhs, rhs).map { $0 - $1 }
+        let partialDistances: [Scalar] = zip(lhs, rhs).map { $0 - $1 }
         let partialDistancesSquared: [Scalar] = partialDistances.map { $0 * $0 }
         let sumOfPartialDistancesSquared: Scalar = partialDistancesSquared.reduce(0.0, +)
         let expected: Scalar = sqrt(sumOfPartialDistancesSquared)
@@ -485,7 +485,7 @@ class VectorTests: XCTestCase {
 
         let actual: Scalar = Surge.dist(lhs, rhs)
 
-        let partialDistances: [Scalar] = Swift.zip(lhs, rhs).map { $0 - $1 }
+        let partialDistances: [Scalar] = zip(lhs, rhs).map { $0 - $1 }
         let partialDistancesSquared: [Scalar] = partialDistances.map { $0 * $0 }
         let expected: Scalar = partialDistancesSquared.reduce(0.0, +)
 
@@ -500,7 +500,7 @@ class VectorTests: XCTestCase {
 
         let actual: Scalar = Surge.dist(lhs, rhs)
 
-        let partialDistances: [Scalar] = Swift.zip(lhs, rhs).map { $0 - $1 }
+        let partialDistances: [Scalar] = zip(lhs, rhs).map { $0 - $1 }
         let partialDistancesSquared: [Scalar] = partialDistances.map { $0 * $0 }
         let expected: Scalar = partialDistancesSquared.reduce(0.0, +)
 

--- a/Tests/SurgeTests/VectorTests.swift
+++ b/Tests/SurgeTests/VectorTests.swift
@@ -28,8 +28,25 @@ class VectorTests: XCTestCase {
     // MARK: - Initialization
 
     func test_init() {
-        let v = Vector([1.0, 2.0])
-        XCTAssertEqual(v.scalars, [1.0, 2.0])
+        typealias Scalar = Double
+
+        let values: [Scalar] = .monotonicNormalized()
+        let lhs: Vector<Scalar> = Vector(values)
+
+        XCTAssertEqual(lhs.scalars, values)
+    }
+
+    // MARK: - Subscript
+
+    func test_subscript() {
+        typealias Scalar = Double
+
+        let values: [Scalar] = .monotonicNormalized()
+        let lhs: Vector<Scalar> = Vector(values)
+
+        for (index, expected) in values.enumerated() {
+            XCTAssertEqual(lhs[index], expected)
+        }
     }
 
     // MARK: - Addition: In Place
@@ -37,18 +54,13 @@ class VectorTests: XCTestCase {
     func test_add_in_place_vector_vector_double() {
         typealias Scalar = Double
 
-        let vector: Vector<Scalar> = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        let lhs: Vector<Scalar> = .monotonicNormalized()
+        let rhs: Vector<Scalar> = .monotonicNormalized()
 
-        var actual: Vector<Scalar> = []
-        measureMetrics([.wallClockTime], automaticallyStartMeasuring: false) {
-            actual = vector
+        var actual: Vector<Scalar> = lhs
+        Surge.addInPlace(&actual, rhs)
 
-            startMeasuring()
-            actual += vector
-            stopMeasuring()
-        }
-
-        let expected: Vector<Scalar> = [2, 4, 6, 8, 10, 12, 14, 16, 18, 20]
+        let expected: Vector<Scalar> = Vector(Swift.zip(lhs, rhs).map { $0 + $1 })
 
         XCTAssertEqual(actual, expected, accuracy: 1e-8)
     }
@@ -56,18 +68,13 @@ class VectorTests: XCTestCase {
     func test_add_in_place_vector_vector_float() {
         typealias Scalar = Float
 
-        let vector: Vector<Scalar> = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        let lhs: Vector<Scalar> = .monotonicNormalized()
+        let rhs: Vector<Scalar> = .monotonicNormalized()
 
-        var actual: Vector<Scalar> = []
-        measureMetrics([.wallClockTime], automaticallyStartMeasuring: false) {
-            actual = vector
+        var actual: Vector<Scalar> = lhs
+        Surge.addInPlace(&actual, rhs)
 
-            startMeasuring()
-            actual += vector
-            stopMeasuring()
-        }
-
-        let expected: Vector<Scalar> = [2, 4, 6, 8, 10, 12, 14, 16, 18, 20]
+        let expected: Vector<Scalar> = Vector(Swift.zip(lhs, rhs).map { $0 + $1 })
 
         XCTAssertEqual(actual, expected, accuracy: 1e-8)
     }
@@ -75,19 +82,13 @@ class VectorTests: XCTestCase {
     func test_add_in_place_vector_scalar_double() {
         typealias Scalar = Double
 
-        let vector: Vector<Scalar> = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-        let scalar: Scalar = 1.0
+        let lhs: Vector<Scalar> = .monotonicNormalized()
+        let rhs: Scalar = .constant()
 
-        var actual: Vector<Scalar> = []
-        measureMetrics([.wallClockTime], automaticallyStartMeasuring: false) {
-            actual = vector
+        var actual: Vector<Scalar> = lhs
+        Surge.addInPlace(&actual, rhs)
 
-            startMeasuring()
-            actual += scalar
-            stopMeasuring()
-        }
-
-        let expected: Vector<Scalar> = [2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
+        let expected: Vector<Scalar> = Vector(lhs.map { $0 + rhs })
 
         XCTAssertEqual(actual, expected, accuracy: 1e-8)
     }
@@ -95,19 +96,13 @@ class VectorTests: XCTestCase {
     func test_add_in_place_vector_scalar_float() {
         typealias Scalar = Float
 
-        let vector: Vector<Scalar> = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-        let scalar: Scalar = 1.0
+        let lhs: Vector<Scalar> = .monotonicNormalized()
+        let rhs: Scalar = .constant()
 
-        var actual: Vector<Scalar> = []
-        measureMetrics([.wallClockTime], automaticallyStartMeasuring: false) {
-            actual = vector
+        var actual: Vector<Scalar> = lhs
+        Surge.addInPlace(&actual, rhs)
 
-            startMeasuring()
-            actual += scalar
-            stopMeasuring()
-        }
-
-        let expected: Vector<Scalar> = [2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
+        let expected: Vector<Scalar> = Vector(lhs.map { $0 + rhs })
 
         XCTAssertEqual(actual, expected, accuracy: 1e-8)
     }
@@ -117,18 +112,13 @@ class VectorTests: XCTestCase {
     func test_sub_in_place_vector_vector_double() {
         typealias Scalar = Double
 
-        let vector: Vector<Scalar> = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        let lhs: Vector<Scalar> = .monotonicNormalized()
+        let rhs: Vector<Scalar> = .monotonicNormalized()
 
-        var actual: Vector<Scalar> = []
-        measureMetrics([.wallClockTime], automaticallyStartMeasuring: false) {
-            actual = vector
+        var actual: Vector<Scalar> = lhs
+        Surge.subInPlace(&actual, rhs)
 
-            startMeasuring()
-            actual -= vector
-            stopMeasuring()
-        }
-
-        let expected: Vector<Scalar> = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+        let expected: Vector<Scalar> = Vector(Swift.zip(lhs, rhs).map { $0 - $1 })
 
         XCTAssertEqual(actual, expected, accuracy: 1e-8)
     }
@@ -136,18 +126,13 @@ class VectorTests: XCTestCase {
     func test_sub_in_place_vector_vector_float() {
         typealias Scalar = Float
 
-        let vector: Vector<Scalar> = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        let lhs: Vector<Scalar> = .monotonicNormalized()
+        let rhs: Vector<Scalar> = .monotonicNormalized()
 
-        var actual: Vector<Scalar> = []
-        measureMetrics([.wallClockTime], automaticallyStartMeasuring: false) {
-            actual = vector
+        var actual: Vector<Scalar> = lhs
+        Surge.subInPlace(&actual, rhs)
 
-            startMeasuring()
-            actual -= vector
-            stopMeasuring()
-        }
-
-        let expected: Vector<Scalar> = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+        let expected: Vector<Scalar> = Vector(Swift.zip(lhs, rhs).map { $0 - $1 })
 
         XCTAssertEqual(actual, expected, accuracy: 1e-8)
     }
@@ -155,19 +140,13 @@ class VectorTests: XCTestCase {
     func test_sub_in_place_vector_scalar_double() {
         typealias Scalar = Double
 
-        let vector: Vector<Scalar> = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-        let scalar: Scalar = 1.0
+        let lhs: Vector<Scalar> = .monotonicNormalized()
+        let rhs: Scalar = .constant()
 
-        var actual: Vector<Scalar> = []
-        measureMetrics([.wallClockTime], automaticallyStartMeasuring: false) {
-            actual = vector
+        var actual: Vector<Scalar> = lhs
+        Surge.subInPlace(&actual, rhs)
 
-            startMeasuring()
-            actual -= scalar
-            stopMeasuring()
-        }
-
-        let expected: Vector<Scalar> = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        let expected: Vector<Scalar> = Vector(lhs.map { $0 - rhs })
 
         XCTAssertEqual(actual, expected, accuracy: 1e-8)
     }
@@ -175,19 +154,13 @@ class VectorTests: XCTestCase {
     func test_sub_in_place_vector_scalar_float() {
         typealias Scalar = Float
 
-        let vector: Vector<Scalar> = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-        let scalar: Scalar = 1.0
+        let lhs: Vector<Scalar> = .monotonicNormalized()
+        let rhs: Scalar = .constant()
 
-        var actual: Vector<Scalar> = []
-        measureMetrics([.wallClockTime], automaticallyStartMeasuring: false) {
-            actual = vector
+        var actual: Vector<Scalar> = lhs
+        Surge.subInPlace(&actual, rhs)
 
-            startMeasuring()
-            actual -= scalar
-            stopMeasuring()
-        }
-
-        let expected: Vector<Scalar> = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        let expected: Vector<Scalar> = Vector(lhs.map { $0 - rhs })
 
         XCTAssertEqual(actual, expected, accuracy: 1e-8)
     }
@@ -197,19 +170,14 @@ class VectorTests: XCTestCase {
     func test_muladd_in_place_vector_vector_double() {
         typealias Scalar = Double
 
-        let vector: Vector<Scalar> = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-        let scalar: Scalar = 2.0
+        let lhs: Vector<Scalar> = .monotonicNormalized()
+        let rhs: Vector<Scalar> = .monotonicNormalized()
+        let alpha: Scalar = .constant()
 
-        var actual: Vector<Scalar> = []
-        measureMetrics([.wallClockTime], automaticallyStartMeasuring: false) {
-            actual = vector
+        var actual: Vector<Scalar> = lhs
+        Surge.muladdInPlace(&actual, rhs, alpha)
 
-            startMeasuring()
-            Surge.muladdInPlace(&actual, vector, scalar)
-            stopMeasuring()
-        }
-
-        let expected: Vector<Scalar> = [3, 6, 9, 12, 15, 18, 21, 24, 27, 30]
+        let expected: Vector<Scalar> = Vector(Swift.zip(lhs.scalars, rhs.scalars).map { $0 + ($1 * alpha) })
 
         XCTAssertEqual(actual, expected, accuracy: 1e-8)
     }
@@ -217,21 +185,16 @@ class VectorTests: XCTestCase {
     func test_muladd_in_place_vector_vector_float() {
         typealias Scalar = Float
 
-        let vector: Vector<Scalar> = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-        let scalar: Scalar = 2.0
+        let lhs: Vector<Scalar> = .monotonicNormalized()
+        let rhs: Vector<Scalar> = .monotonicNormalized()
+        let alpha: Scalar = .constant()
 
-        var actual: Vector<Scalar> = []
-        measureMetrics([.wallClockTime], automaticallyStartMeasuring: false) {
-            actual = vector
+        var actual: Vector<Scalar> = lhs
+        Surge.muladdInPlace(&actual, rhs, alpha)
 
-            startMeasuring()
-            Surge.muladdInPlace(&actual, vector, scalar)
-            stopMeasuring()
-        }
+        let expected: Vector<Scalar> = Vector(Swift.zip(lhs.scalars, rhs.scalars).map { $0 + ($1 * alpha) })
 
-        let expected: Vector<Scalar> = [3, 6, 9, 12, 15, 18, 21, 24, 27, 30]
-
-        XCTAssertEqual(actual, expected, accuracy: 1e-8)
+        XCTAssertEqual(actual, expected, accuracy: 1e-6)
     }
 
     // MARK: - Multiplication: In Place
@@ -239,19 +202,13 @@ class VectorTests: XCTestCase {
     func test_mul_in_place_vector_scalar_double() {
         typealias Scalar = Double
 
-        let vector: Vector<Scalar> = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-        let scalar: Scalar = 2.0
+        let lhs: Vector<Scalar> = .monotonicNormalized()
+        let rhs: Scalar = .constant()
 
-        var actual: Vector<Scalar> = []
-        measureMetrics([.wallClockTime], automaticallyStartMeasuring: false) {
-            actual = vector
+        var actual: Vector<Scalar> = lhs
+        Surge.mulInPlace(&actual, rhs)
 
-            startMeasuring()
-            actual *= scalar
-            stopMeasuring()
-        }
-
-        let expected: Vector<Scalar> = [2, 4, 6, 8, 10, 12, 14, 16, 18, 20]
+        let expected: Vector<Scalar> = Vector(lhs.map { $0 * rhs })
 
         XCTAssertEqual(actual, expected, accuracy: 1e-8)
     }
@@ -259,21 +216,51 @@ class VectorTests: XCTestCase {
     func test_mul_in_place_vector_scalar_float() {
         typealias Scalar = Float
 
-        let vector: Vector<Scalar> = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-        let scalar: Scalar = 2.0
+        let lhs: Vector<Scalar> = .monotonicNormalized()
+        let rhs: Scalar = .constant()
 
-        var actual: Vector<Scalar> = []
-        measureMetrics([.wallClockTime], automaticallyStartMeasuring: false) {
-            actual = vector
+        var actual: Vector<Scalar> = lhs
+        Surge.mulInPlace(&actual, rhs)
 
-            startMeasuring()
-            actual *= scalar
-            stopMeasuring()
-        }
-
-        let expected: Vector<Scalar> = [2, 4, 6, 8, 10, 12, 14, 16, 18, 20]
+        let expected: Vector<Scalar> = Vector(lhs.map { $0 * rhs })
 
         XCTAssertEqual(actual, expected, accuracy: 1e-8)
+    }
+
+    func test_mul_vector_matrix_double() {
+        typealias Scalar = Double
+
+        let lhs: Vector<Scalar> = .monotonicNormalized()
+        let rhs: Matrix<Scalar> = .monotonicNormalized()
+
+        let actual: Vector<Scalar> = Surge.mul(lhs, rhs)
+
+        let transposed: Matrix<Scalar> = Surge.transpose(rhs)
+        let columns: [Vector<Scalar>] = transposed.map { Vector($0) }
+        let expected: Vector<Scalar> = Vector(columns.map { rhs in
+            let squares: [Scalar] = Swift.zip(lhs, rhs).map { $0 * $1 }
+            return squares.reduce(0.0, +)
+        })
+
+        XCTAssertEqual(actual, expected, accuracy: 1e-8)
+    }
+
+    func test_mul_vector_matrix_float() {
+        typealias Scalar = Float
+
+        let lhs: Vector<Scalar> = .monotonicNormalized()
+        let rhs: Matrix<Scalar> = .monotonicNormalized()
+
+        let actual: Vector<Scalar> = Surge.mul(lhs, rhs)
+
+        let transposed: Matrix<Scalar> = Surge.transpose(rhs)
+        let columns: [Vector<Scalar>] = transposed.map { Vector($0) }
+        let expected: Vector<Scalar> = Vector(columns.map { rhs in
+            let squares: [Scalar] = Swift.zip(lhs, rhs).map { $0 * $1 }
+            return squares.reduce(0.0, +)
+        })
+
+        XCTAssertEqual(actual, expected, accuracy: 1e-3)
     }
 
     // MARK: - Division: In Place
@@ -281,19 +268,13 @@ class VectorTests: XCTestCase {
     func test_div_in_place_vector_scalar_double() {
         typealias Scalar = Double
 
-        let vector: Vector<Scalar> = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-        let scalar: Scalar = 0.5
+        let lhs: Vector<Scalar> = .monotonicNormalized()
+        let rhs: Scalar = .constant()
 
-        var actual: Vector<Scalar> = []
-        measureMetrics([.wallClockTime], automaticallyStartMeasuring: false) {
-            actual = vector
+        var actual: Vector<Scalar> = lhs
+        Surge.divInPlace(&actual, rhs)
 
-            startMeasuring()
-            actual /= scalar
-            stopMeasuring()
-        }
-
-        let expected: Vector<Scalar> = [2, 4, 6, 8, 10, 12, 14, 16, 18, 20]
+        let expected: Vector<Scalar> = Vector(lhs.map { $0 / rhs })
 
         XCTAssertEqual(actual, expected, accuracy: 1e-8)
     }
@@ -301,19 +282,13 @@ class VectorTests: XCTestCase {
     func test_div_in_place_vector_scalar_float() {
         typealias Scalar = Float
 
-        let vector: Vector<Scalar> = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-        let scalar: Scalar = 0.5
+        let lhs: Vector<Scalar> = .monotonicNormalized()
+        let rhs: Scalar = .constant()
 
-        var actual: Vector<Scalar> = []
-        measureMetrics([.wallClockTime], automaticallyStartMeasuring: false) {
-            actual = vector
+        var actual: Vector<Scalar> = lhs
+        Surge.divInPlace(&actual, rhs)
 
-            startMeasuring()
-            actual /= scalar
-            stopMeasuring()
-        }
-
-        let expected: Vector<Scalar> = [2, 4, 6, 8, 10, 12, 14, 16, 18, 20]
+        let expected: Vector<Scalar> = Vector(lhs.map { $0 / rhs })
 
         XCTAssertEqual(actual, expected, accuracy: 1e-5)
     }
@@ -323,18 +298,13 @@ class VectorTests: XCTestCase {
     func test_elmul_in_place_double() {
         typealias Scalar = Double
 
-        let vector: Vector<Scalar> = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        let lhs: Vector<Scalar> = .monotonicNormalized()
+        let rhs: Vector<Scalar> = .monotonicNormalized()
 
-        var actual: Vector<Scalar> = []
-        measureMetrics([.wallClockTime], automaticallyStartMeasuring: false) {
-            actual = vector
+        var actual: Vector<Scalar> = lhs
+        Surge.elmulInPlace(&actual, rhs)
 
-            startMeasuring()
-            actual .*= vector
-            stopMeasuring()
-        }
-
-        let expected: Vector<Scalar> = [1, 4, 9, 16, 25, 36, 49, 64, 81, 100]
+        let expected: Vector<Scalar> = Vector(Swift.zip(lhs, rhs).map { $0 * $1 })
 
         XCTAssertEqual(actual, expected, accuracy: 1e-8)
     }
@@ -342,18 +312,13 @@ class VectorTests: XCTestCase {
     func test_elmul_in_place_float() {
         typealias Scalar = Float
 
-        let vector: Vector<Scalar> = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        let lhs: Vector<Scalar> = .monotonicNormalized()
+        let rhs: Vector<Scalar> = .monotonicNormalized()
 
-        var actual: Vector<Scalar> = []
-        measureMetrics([.wallClockTime], automaticallyStartMeasuring: false) {
-            actual = vector
+        var actual: Vector<Scalar> = lhs
+        Surge.elmulInPlace(&actual, rhs)
 
-            startMeasuring()
-            actual .*= vector
-            stopMeasuring()
-        }
-
-        let expected: Vector<Scalar> = [1, 4, 9, 16, 25, 36, 49, 64, 81, 100]
+        let expected: Vector<Scalar> = Vector(Swift.zip(lhs, rhs).map { $0 * $1 })
 
         XCTAssertEqual(actual, expected, accuracy: 1e-8)
     }
@@ -363,18 +328,13 @@ class VectorTests: XCTestCase {
     func test_eldiv_in_place_double() {
         typealias Scalar = Double
 
-        let vector: Vector<Scalar> = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        let lhs: Vector<Scalar> = .monotonicNormalized()
+        let rhs: Vector<Scalar> = .monotonicNormalized()
 
-        var actual: Vector<Scalar> = []
-        measureMetrics([.wallClockTime], automaticallyStartMeasuring: false) {
-            actual = vector
+        var actual: Vector<Scalar> = lhs
+        Surge.eldivInPlace(&actual, rhs)
 
-            startMeasuring()
-            actual ./= vector
-            stopMeasuring()
-        }
-
-        let expected: Vector<Scalar> = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+        let expected: Vector<Scalar> = Vector(Swift.zip(lhs, rhs).map { $0 / $1 })
 
         XCTAssertEqual(actual, expected, accuracy: 1e-8)
     }
@@ -382,31 +342,29 @@ class VectorTests: XCTestCase {
     func test_eldiv_in_place_float() {
         typealias Scalar = Float
 
-        let vector: Vector<Scalar> = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        let lhs: Vector<Scalar> = .monotonicNormalized()
+        let rhs: Vector<Scalar> = .monotonicNormalized()
 
-        var actual: Vector<Scalar> = []
-        measureMetrics([.wallClockTime], automaticallyStartMeasuring: false) {
-            actual = vector
+        var actual: Vector<Scalar> = lhs
+        Surge.eldivInPlace(&actual, rhs)
 
-            startMeasuring()
-            actual ./= vector
-            stopMeasuring()
-        }
-
-        let expected: Vector<Scalar> = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+        let expected: Vector<Scalar> = Vector(Swift.zip(lhs, rhs).map { $0 / $1 })
 
         XCTAssertEqual(actual, expected, accuracy: 1e-6)
     }
 
-    // MARK: - Dot Product
+    // MARK: - Dot Product: In Place
 
     func test_dot_vector_vector_double() {
         typealias Scalar = Double
 
-        let vector: Vector<Scalar> = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        let lhs: Vector<Scalar> = .monotonicNormalized()
+        let rhs: Vector<Scalar> = .monotonicNormalized()
 
-        let actual = dot(vector, vector)
-        let expected: Scalar = 385
+        let actual: Scalar = Surge.dot(lhs, rhs)
+
+        let squares: [Scalar] = Swift.zip(lhs, rhs).map { $0 * $1 }
+        let expected: Scalar = squares.reduce(0.0, +)
 
         XCTAssertEqual(actual, expected, accuracy: 1e-8)
     }
@@ -414,12 +372,15 @@ class VectorTests: XCTestCase {
     func test_dot_vector_vector_float() {
         typealias Scalar = Float
 
-        let vector: Vector<Scalar> = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        let lhs: Vector<Scalar> = .monotonicNormalized()
+        let rhs: Vector<Scalar> = .monotonicNormalized()
 
-        let actual = dot(vector, vector)
-        let expected: Scalar = 385
+        let actual: Scalar = Surge.dot(lhs, rhs)
 
-        XCTAssertEqual(actual, expected, accuracy: 1e-5)
+        let squares: [Scalar] = Swift.zip(lhs, rhs).map { $0 * $1 }
+        let expected: Scalar = squares.reduce(0.0, +)
+
+        XCTAssertEqual(actual, expected, accuracy: 1e-3)
     }
 
     // MARK: - Power
@@ -427,18 +388,13 @@ class VectorTests: XCTestCase {
     func test_pow_in_place_vector_scalar_double() {
         typealias Scalar = Double
 
-        let vector: Vector<Scalar> = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-        let scalar: Scalar = 2.0
+        let lhs: Vector<Scalar> = .monotonicNormalized()
+        let rhs: Scalar = .constant()
 
-        var actual: Vector<Scalar> = []
-        measureMetrics([.wallClockTime], automaticallyStartMeasuring: false) {
-            actual = vector
+        var actual: Vector<Scalar> = lhs
+        Surge.powInPlace(&actual, rhs)
 
-            startMeasuring()
-            powInPlace(&actual, scalar)
-            stopMeasuring()
-        }
-        let expected: Vector<Scalar> = [1, 4, 9, 16, 25, 36, 49, 64, 81, 100]
+        let expected: Vector<Scalar> = Vector(lhs.map { pow($0, rhs) })
 
         XCTAssertEqual(actual, expected, accuracy: 1e-8)
     }
@@ -446,18 +402,13 @@ class VectorTests: XCTestCase {
     func test_pow_in_place_vector_scalar_float() {
         typealias Scalar = Float
 
-        let vector: Vector<Scalar> = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-        let scalar: Scalar = 2.0
+        let lhs: Vector<Scalar> = .monotonicNormalized()
+        let rhs: Scalar = .constant()
 
-        var actual: Vector<Scalar> = []
-        measureMetrics([.wallClockTime], automaticallyStartMeasuring: false) {
-            actual = vector
+        var actual: Vector<Scalar> = lhs
+        Surge.powInPlace(&actual, rhs)
 
-            startMeasuring()
-            powInPlace(&actual, scalar)
-            stopMeasuring()
-        }
-        let expected: Vector<Scalar> = [1, 4, 9, 16, 25, 36, 49, 64, 81, 100]
+        let expected: Vector<Scalar> = Vector(lhs.map { pow($0, rhs) })
 
         XCTAssertEqual(actual, expected, accuracy: 1e-5)
     }
@@ -467,20 +418,12 @@ class VectorTests: XCTestCase {
     func test_exp_in_place_vector_double() {
         typealias Scalar = Double
 
-        let vector: Vector<Scalar> = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        let lhs: Vector<Scalar> = .monotonicNormalized()
 
-        var actual: Vector<Scalar> = []
-        measureMetrics([.wallClockTime], automaticallyStartMeasuring: false) {
-            actual = vector
+        var actual: Vector<Scalar> = lhs
+        Surge.expInPlace(&actual)
 
-            startMeasuring()
-            expInPlace(&actual)
-            stopMeasuring()
-        }
-        let expected: Vector<Scalar> = [
-            2.718_282, 7.389_056, 20.085_537, 54.598_150, 148.413_159,
-            403.428_793, 1_096.633_158, 2_980.957_987, 8_103.083_928, 22_026.465_795
-        ]
+        let expected: Vector<Scalar> = Vector(lhs.map { exp($0) })
 
         XCTAssertEqual(actual, expected, accuracy: 1e-6)
     }
@@ -488,20 +431,12 @@ class VectorTests: XCTestCase {
     func test_exp_in_place_vector_float() {
         typealias Scalar = Float
 
-        let vector: Vector<Scalar> = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        let lhs: Vector<Scalar> = .monotonicNormalized()
 
-        var actual: Vector<Scalar> = []
-        measureMetrics([.wallClockTime], automaticallyStartMeasuring: false) {
-            actual = vector
+        var actual: Vector<Scalar> = lhs
+        Surge.expInPlace(&actual)
 
-            startMeasuring()
-            expInPlace(&actual)
-            stopMeasuring()
-        }
-        let expected: Vector<Scalar> = [
-            2.718_282, 7.389_056, 20.085_537, 54.598_150, 148.413_159,
-            403.428_793, 1_096.633_158, 2_980.957_987, 8_103.083_928, 22_026.465_795
-        ]
+        let expected: Vector<Scalar> = Vector(lhs.map { exp($0) })
 
         XCTAssertEqual(actual, expected, accuracy: 1e-2)
     }
@@ -511,14 +446,15 @@ class VectorTests: XCTestCase {
     func test_dist_vector_vector_double() {
         typealias Scalar = Double
 
-        let lhs: Vector<Scalar> = [1, 2, 3]
-        let rhs: Vector<Scalar> = [9, 8, 7]
+        let lhs: Vector<Scalar> = .monotonicNormalized()
+        let rhs: Vector<Scalar> = .monotonicNormalized()
 
-        var actual: Scalar = 0
-        measure {
-            actual = dist(lhs, rhs)
-        }
-        let expected: Scalar = sqrt(Swift.zip(lhs, rhs).map({ $0 - $1 }).map({ $0 * $0 }).reduce(0.0, +))
+        let actual: Scalar = Surge.dist(lhs, rhs)
+
+        let partialDistances: [Scalar] = Swift.zip(lhs, rhs).map { $0 - $1 }
+        let partialDistancesSquared: [Scalar] = partialDistances.map { $0 * $0 }
+        let sumOfPartialDistancesSquared: Scalar = partialDistancesSquared.reduce(0.0, +)
+        let expected: Scalar = sqrt(sumOfPartialDistancesSquared)
 
         XCTAssertEqual(actual, expected, accuracy: 1e-6)
     }
@@ -526,14 +462,15 @@ class VectorTests: XCTestCase {
     func test_dist_vector_vector_float() {
         typealias Scalar = Float
 
-        let lhs: Vector<Scalar> = [1, 2, 3, 4]
-        let rhs: Vector<Scalar> = [9, 8, 7, 6]
+        let lhs: Vector<Scalar> = .monotonicNormalized()
+        let rhs: Vector<Scalar> = .monotonicNormalized()
 
-        var actual: Scalar = 0
-        measure {
-            actual = dist(lhs, rhs)
-        }
-        let expected: Scalar = sqrt(Swift.zip(lhs, rhs).map({ $0 - $1 }).map({ $0 * $0 }).reduce(0.0, +))
+        let actual: Scalar = Surge.dist(lhs, rhs)
+
+        let partialDistances: [Scalar] = Swift.zip(lhs, rhs).map { $0 - $1 }
+        let partialDistancesSquared: [Scalar] = partialDistances.map { $0 * $0 }
+        let sumOfPartialDistancesSquared: Scalar = partialDistancesSquared.reduce(0.0, +)
+        let expected: Scalar = sqrt(sumOfPartialDistancesSquared)
 
         XCTAssertEqual(actual, expected, accuracy: 1e-6)
     }
@@ -543,15 +480,14 @@ class VectorTests: XCTestCase {
     func test_distsq_vector_vector_double() {
         typealias Scalar = Double
 
-        let lhs: Vector<Scalar> = [1, 2, 3]
-        let rhs: Vector<Scalar> = [9, 8, 7]
+        let lhs: Vector<Scalar> = .monotonicNormalized()
+        let rhs: Vector<Scalar> = .monotonicNormalized()
 
-        var actual: Scalar = 0
-        measure {
-            actual = distSq(lhs, rhs)
-        }
+        let actual: Scalar = Surge.dist(lhs, rhs)
 
-        let expected: Scalar = Swift.zip(lhs, rhs).map({ $0 - $1 }).map({ $0 * $0 }).reduce(0.0, +)
+        let partialDistances: [Scalar] = Swift.zip(lhs, rhs).map { $0 - $1 }
+        let partialDistancesSquared: [Scalar] = partialDistances.map { $0 * $0 }
+        let expected: Scalar = partialDistancesSquared.reduce(0.0, +)
 
         XCTAssertEqual(actual, expected, accuracy: 1e-6)
     }
@@ -559,14 +495,14 @@ class VectorTests: XCTestCase {
     func test_distsq_vector_vector_float() {
         typealias Scalar = Float
 
-        let lhs: Vector<Scalar> = [1, 2, 3, 4]
-        let rhs: Vector<Scalar> = [9, 8, 7, 6]
+        let lhs: Vector<Scalar> = .monotonicNormalized()
+        let rhs: Vector<Scalar> = .monotonicNormalized()
 
-        var actual: Scalar = 0
-        measure {
-            actual = distSq(lhs, rhs)
-        }
-        let expected: Scalar = Swift.zip(lhs, rhs).map({ $0 - $1 }).map({ $0 * $0 }).reduce(0.0, +)
+        let actual: Scalar = Surge.dist(lhs, rhs)
+
+        let partialDistances: [Scalar] = Swift.zip(lhs, rhs).map { $0 - $1 }
+        let partialDistancesSquared: [Scalar] = partialDistances.map { $0 * $0 }
+        let expected: Scalar = partialDistancesSquared.reduce(0.0, +)
 
         XCTAssertEqual(actual, expected, accuracy: 1e-6)
     }

--- a/Tests/SurgeTests/XCTAssert+Surge.swift
+++ b/Tests/SurgeTests/XCTAssert+Surge.swift
@@ -89,7 +89,7 @@ private func checkArray<T, U>(
         return .failure(.size(message: message))
     }
 
-    for (index, (actualValue, expectedValue)) in Swift.zip(actualArray, expectedArray).enumerated() {
+    for (index, (actualValue, expectedValue)) in zip(actualArray, expectedArray).enumerated() {
         switch checkValue(actualValue, expectedValue, accuracy: accuracy) {
         case .success:
             continue
@@ -112,7 +112,7 @@ private func checkGrid<T, U, V>(
         return .failure(.size(message: message))
     }
 
-    for (index, (actualArray, expectedArray)) in Swift.zip(actualGrid, expectedGrid).enumerated() {
+    for (index, (actualArray, expectedArray)) in zip(actualGrid, expectedGrid).enumerated() {
         switch checkArray(actualArray, expectedArray, accuracy: accuracy) {
         case .success:
             continue


### PR DESCRIPTION
Vector's operations shallowly wrap those from "Arithmetic", so there's really no point in benchmarking them, when we already have benchmarks in place for the latter.

Vector tests now also moved from explicit `expected` values via literals to ad-hoc un-optimized calculations of the operation.