### PR TITLE
Fix member access-levels of `MatrixEigenDecompositionResult<Scalar>`

### DIFF
--- a/Sources/Surge/Linear Algebra/Matrix.swift
+++ b/Sources/Surge/Linear Algebra/Matrix.swift
@@ -157,9 +157,9 @@ extension Matrix: ExpressibleByArrayLiteral where Scalar: FloatingPoint, Scalar:
 /// Holds the result of eigendecomposition. The (Scalar, Scalar) used
 /// in the property types represents a complex number with (real, imaginary) parts.
 public struct MatrixEigenDecompositionResult<Scalar> where Scalar: FloatingPoint, Scalar: ExpressibleByFloatLiteral {
-    let eigenValues: [(Scalar, Scalar)]
-    let leftEigenVectors: [[(Scalar, Scalar)]]
-    let rightEigenVectors: [[(Scalar, Scalar)]]
+    public let eigenValues: [(Scalar, Scalar)]
+    public let leftEigenVectors: [[(Scalar, Scalar)]]
+    public let rightEigenVectors: [[(Scalar, Scalar)]]
 
     public init(eigenValues: [(Scalar, Scalar)], leftEigenVectors: [[(Scalar, Scalar)]], rightEigenVectors: [[(Scalar, Scalar)]]) {
         self.eigenValues = eigenValues


### PR DESCRIPTION
Hi @loufranco, you added the following struct to Surge in https://github.com/mattt/Surge/pull/95 (https://github.com/mattt/Surge/commit/a6dd5f622ed5f36c74ead2dc54329a2d8f39f855), earlier this year, along with the corresponding eigen-decomposition logic to go with it:

```swift
public struct MatrixEigenDecompositionResult<Scalar> where Scalar: FloatingPoint, Scalar: ExpressibleByFloatLiteral {
    let eigenValues: [(Scalar, Scalar)]
    let leftEigenVectors: [[(Scalar, Scalar)]]
    let rightEigenVectors: [[(Scalar, Scalar)]]

    // ...
}
```

From this [issue](https://github.com/mattt/Surge/issues/131) it seems that the members of said type are inaccessible when accessed from a third-party module, due to being implicitly marked as `internal`.

So I was wondering if you could tell me if I'd be right to assume that the internal access level a simple oversight and adding `public` is in line with the intended usage of the API?