### PR TITLE
Added closure-based initializers for `Matrix` & `Vector` and corresponding unit test

### DIFF
--- a/Sources/Surge/Linear Algebra/Matrix.swift
+++ b/Sources/Surge/Linear Algebra/Matrix.swift
@@ -65,6 +65,19 @@ public struct Matrix<Scalar> where Scalar: FloatingPoint, Scalar: ExpressibleByF
         self.grid = grid
     }
 
+    public init(rows: Int, columns: Int, _ closure: (_ row: Int, _ column: Int) throws -> Scalar) rethrows {
+        var grid: [Scalar] = []
+        grid.reserveCapacity(rows * columns)
+
+        for row in 0..<rows {
+            for column in 0..<columns {
+                grid.append(try closure(row, column))
+            }
+        }
+
+        self.init(rows: rows, columns: columns, grid: grid)
+    }
+
     public static func identity(size: Int) -> Matrix<Scalar> {
         return self.diagonal(rows: size, columns: size, repeatedValue: 1.0)
     }

--- a/Sources/Surge/Linear Algebra/Vector.swift
+++ b/Sources/Surge/Linear Algebra/Vector.swift
@@ -46,6 +46,17 @@ public struct Vector<Scalar> where Scalar: FloatingPoint, Scalar: ExpressibleByF
         self.dimensions = scalars.count
         self.scalars = scalars
     }
+
+    public init(dimensions: Int, _ closure: (Int) throws -> Scalar) rethrows {
+        var scalars: [Scalar] = []
+        scalars.reserveCapacity(dimensions)
+
+        for index in 0..<dimensions {
+            scalars.append(try closure(index))
+        }
+
+        self.init(scalars)
+    }
 }
 
 // MARK: - ExpressibleByArrayLiteral

--- a/Tests/SurgeTests/MatrixTests.swift
+++ b/Tests/SurgeTests/MatrixTests.swift
@@ -99,6 +99,22 @@ class MatrixTests: XCTestCase {
         XCTAssertEqual(actual, expected)
     }
 
+    func test_init_rows_columns_closure() {
+        typealias Scalar = Double
+
+        let columns = 4
+        let actual: Matrix<Scalar> = Matrix(rows: 3, columns: columns) { row, column in
+            Scalar((row * columns) + column)
+        }
+        let expected: Matrix<Scalar> = [
+            [0, 1, 2, 3],
+            [4, 5, 6, 7],
+            [8, 9, 10, 11],
+        ]
+
+        XCTAssertEqual(actual, expected)
+    }
+
     func test_init_arrayLiteral() {
         typealias Scalar = Double
 

--- a/Tests/SurgeTests/VectorTests.swift
+++ b/Tests/SurgeTests/VectorTests.swift
@@ -27,6 +27,19 @@ import XCTest
 class VectorTests: XCTestCase {
     // MARK: - Initialization
 
+    func test_init_dimensions_repeatedValue() {
+        typealias Scalar = Double
+
+        let dimensions = 5
+        let repeatedValue: Scalar = 42
+
+        let actual: Vector<Scalar> = Vector(dimensions: dimensions, repeatedValue: repeatedValue)
+
+        let expected: Vector<Scalar> = [42, 42, 42, 42, 42]
+
+        XCTAssertEqual(actual, expected)
+    }
+
     func test_init() {
         typealias Scalar = Double
 
@@ -34,6 +47,16 @@ class VectorTests: XCTestCase {
         let lhs: Vector<Scalar> = Vector(values)
 
         XCTAssertEqual(lhs.scalars, values)
+    }
+
+    func test_init_dimensions_closure() {
+        typealias Scalar = Double
+
+        let dimensions = 5
+        let actual: Vector<Scalar> = Vector(dimensions: dimensions) { Scalar($0) }
+        let expected: Vector<Scalar> = [0, 1, 2, 3, 4]
+
+        XCTAssertEqual(actual, expected)
     }
 
     // MARK: - Subscript


### PR DESCRIPTION
Addresses https://github.com/mattt/Surge/issues/85